### PR TITLE
Fix 3D rendering on macOS

### DIFF
--- a/src/Editor/main.cpp
+++ b/src/Editor/main.cpp
@@ -81,6 +81,12 @@ public:
     /** Main function */
     int Main(int argc, char *argv[])
     {
+        // Default OpenGL format
+        QSurfaceFormat glFormat;
+        glFormat.setVersion(3, 3);
+        glFormat.setProfile(QSurfaceFormat::CoreProfile);
+        QSurfaceFormat::setDefaultFormat(glFormat);
+
         // Create application
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
         QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
@@ -106,12 +112,6 @@ public:
         gpMouseDragCocoaEventFilter = &mouseDragCocoaEventFilter;
         qApp->installNativeEventFilter(gpMouseDragCocoaEventFilter);
 #endif
-
-        // Default OpenGL format
-        QSurfaceFormat glFormat;
-        glFormat.setVersion(3, 3);
-        glFormat.setProfile(QSurfaceFormat::CoreProfile);
-        QSurfaceFormat::setDefaultFormat(glFormat);
 
         // Init log
         bool Initialized = NLog::InitLog(LocateLogPath());


### PR DESCRIPTION
At some point, a change in Qt broke 3D rendering on macOS. Unless the default surface format is set to require a core context before the `CEditorApplication` instance is constructed, the following warning is printed, which I think speaks for itself:
`Qt Warning: Could not create NSOpenGLContext with shared context, falling back to unshared context.` Frankly, I'm not sure why this ever worked before.