### PR TITLE
Fix incorrect reporting of script instance ids

### DIFF
--- a/src/Core/Resource/Script/CScriptObject.h
+++ b/src/Core/Resource/Script/CScriptObject.h
@@ -24,7 +24,6 @@ public:
     CInstanceID() = default;
     CInstanceID(uint32 id) : mId(id) {}
     CInstanceID& operator=(uint32 id) { mId = id; return *this; }
-    uint8 Layer() const { return uint8((mId >> 26u) & 0x3fu); }
     uint16 Area() const { return uint16((mId >> 16u) & 0x3ffu); }
     uint16 Id() const { return uint16(mId & 0xffffu); }
 };

--- a/src/Editor/WorldEditor/WEditorProperties.cpp
+++ b/src/Editor/WorldEditor/WEditorProperties.cpp
@@ -133,12 +133,13 @@ void WEditorProperties::OnSelectionModified()
     {
         CScriptNode *pScript = static_cast<CScriptNode*>(mpDisplayNode);
         CInstanceID InstanceID = pScript->Instance()->InstanceID();
+        uint32_t LayerNum = pScript->Instance()->Layer()->AreaIndex();
         TString ObjectType = pScript->Template()->Name();
         mpInstanceInfoLabel->setText(QString("[%1] [%2]").
                                      arg( TO_QSTRING(ObjectType) ).
-                                     arg( TO_QSTRING(TString::HexString(InstanceID, 8, false)) ));
+                                     arg( TO_QSTRING(TString::HexString(InstanceID | (LayerNum << 26), 8, false)) ));
         mpInstanceInfoLabel->setToolTip(QString("[Layer: %1] [Area: %2] [ID: %3]").
-                                        arg( InstanceID.Layer() ).
+                                        arg( LayerNum ).
                                         arg( InstanceID.Area() ).
                                         arg( TO_QSTRING(TString::HexString(InstanceID.Id(), 4, false)) ));
 


### PR DESCRIPTION
The layer component of `InstanceID` isn't maintained so that objects can be moved across layers without updating every script connection. As a consequence of that, the GUI was reporting an incorrect instance ids for objects not on layer 0. I'm not sure if this is the right approach to fixing the problem; it is kind of a hack to just re-add the layer information in the GUI.