### PR TITLE
Include QCloseEvent in IEditor.cpp

### DIFF
--- a/src/Editor/IEditor.cpp
+++ b/src/Editor/IEditor.cpp
@@ -5,6 +5,7 @@
 #include <QMenu>
 #include <QMessageBox>
 #include <QToolBar>
+#include <QCloseEvent>
 
 IEditor::IEditor(QWidget* pParent)
     : QMainWindow(pParent)


### PR DESCRIPTION
Without this include, project fails to build on Arch Linux with gcc 9.3.0 with the following error:
```
../src/Editor/IEditor.cpp:79:15: error: invalid use of incomplete type ‘class QCloseEvent’
   79 |         pEvent->ignore();
      |               ^~
```