### PR TITLE
CAnimationParameters: Add missing break in switch cases in SetUnknown() 

### DIFF
--- a/src/Core/Resource/Animation/CAnimationParameters.cpp
+++ b/src/Core/Resource/Animation/CAnimationParameters.cpp
@@ -2,33 +2,16 @@
 #include "CAnimSet.h"
 #include "Core/GameProject/CResourceStore.h"
 #include <Common/Log.h>
-#include <iostream>
 
-CAnimationParameters::CAnimationParameters()
-    : mGame(EGame::Prime)
-    , mCharIndex(0)
-    , mAnimIndex(0)
-    , mUnknown2(0)
-    , mUnknown3(0)
-{
-}
+CAnimationParameters::CAnimationParameters() = default;
 
 CAnimationParameters::CAnimationParameters(EGame Game)
-    : mGame(Game)
-    , mCharacterID( CAssetID::InvalidID(Game) )
-    , mCharIndex(0)
-    , mAnimIndex(0)
-    , mUnknown2(0)
-    , mUnknown3(0)
+    : mGame(Game), mCharacterID(CAssetID::InvalidID(Game))
 {
 }
 
 CAnimationParameters::CAnimationParameters(IInputStream& rSCLY, EGame Game)
     : mGame(Game)
-    , mCharIndex(0)
-    , mAnimIndex(0)
-    , mUnknown2(0)
-    , mUnknown3(0)
 {
     if (Game <= EGame::Echoes)
     {

--- a/src/Core/Resource/Animation/CAnimationParameters.cpp
+++ b/src/Core/Resource/Animation/CAnimationParameters.cpp
@@ -208,8 +208,14 @@ void CAnimationParameters::SetUnknown(uint32 Index, uint32 Value)
 {
     switch (Index)
     {
-    case 0: mAnimIndex = Value;
-    case 1: mUnknown2 = Value;
-    case 2: mUnknown3 = Value;
+    case 0:
+        mAnimIndex = Value;
+        break;
+    case 1:
+        mUnknown2 = Value;
+        break;
+    case 2:
+        mUnknown3 = Value;
+        break;
     }
 }

--- a/src/Core/Resource/Animation/CAnimationParameters.h
+++ b/src/Core/Resource/Animation/CAnimationParameters.h
@@ -8,13 +8,13 @@ class CModel;
 
 class CAnimationParameters
 {
-    EGame mGame;
+    EGame mGame = EGame::Prime;
     CAssetID mCharacterID;
 
-    uint32 mCharIndex;
-    uint32 mAnimIndex;
-    uint32 mUnknown2;
-    uint32 mUnknown3;
+    uint32 mCharIndex = 0;
+    uint32 mAnimIndex = 0;
+    uint32 mUnknown2 = 0;
+    uint32 mUnknown3 = 0;
 
 public:
     CAnimationParameters();


### PR DESCRIPTION
Prevents undocumented switch fallthrough. While we're in the same area, we can make use of in-class member initializers.