### PR TITLE
CPoiToWorld: Make use of std::unique_ptr where applicable 

### DIFF
--- a/src/Core/Resource/CPoiToWorld.cpp
+++ b/src/Core/Resource/CPoiToWorld.cpp
@@ -5,25 +5,22 @@ CPoiToWorld::CPoiToWorld(CResourceEntry *pEntry /*= 0*/)
 {
 }
 
-CPoiToWorld::~CPoiToWorld()
-{
-    for (auto it = mMaps.begin(); it != mMaps.end(); it++)
-        delete *it;
-}
+CPoiToWorld::~CPoiToWorld() = default;
 
 void CPoiToWorld::AddPoi(uint32 PoiID)
 {
     // Check if this POI already exists
-    auto it = mPoiLookupMap.find(PoiID);
-
-    if (it == mPoiLookupMap.end())
+    const auto it = mPoiLookupMap.find(PoiID);
+    if (it != mPoiLookupMap.cend())
     {
-        SPoiMap *pMap = new SPoiMap();
-        pMap->PoiID = PoiID;
-
-        mMaps.push_back(pMap);
-        mPoiLookupMap[PoiID] = pMap;
+        return;
     }
+
+    auto pMap = std::make_unique<SPoiMap>();
+    pMap->PoiID = PoiID;
+
+    mPoiLookupMap.insert_or_assign(PoiID, pMap.get());
+    mMaps.push_back(std::move(pMap));
 }
 
 void CPoiToWorld::AddPoiMeshMap(uint32 PoiID, uint32 ModelID)

--- a/src/Core/Resource/CPoiToWorld.cpp
+++ b/src/Core/Resource/CPoiToWorld.cpp
@@ -1,5 +1,7 @@
 #include "CPoiToWorld.h"
 
+#include <algorithm>
+
 CPoiToWorld::CPoiToWorld(CResourceEntry *pEntry /*= 0*/)
     : CResource(pEntry)
 {
@@ -30,10 +32,11 @@ void CPoiToWorld::AddPoiMeshMap(uint32 PoiID, uint32 ModelID)
     SPoiMap *pMap = mPoiLookupMap[PoiID];
 
     // Check whether this model ID is already mapped to this POI
-    for (auto it = pMap->ModelIDs.begin(); it != pMap->ModelIDs.end(); it++)
+    const bool exists = std::any_of(pMap->ModelIDs.cbegin(), pMap->ModelIDs.cend(),
+                                    [ModelID](const auto ID) { return ID == ModelID; });
+    if (exists)
     {
-        if (*it == ModelID)
-            return;
+        return;
     }
 
     // We didn't return, so this is a new mapping
@@ -42,7 +45,7 @@ void CPoiToWorld::AddPoiMeshMap(uint32 PoiID, uint32 ModelID)
 
 void CPoiToWorld::RemovePoi(uint32 PoiID)
 {
-    for (auto it = mMaps.begin(); it != mMaps.end(); it++)
+    for (auto it = mMaps.begin(); it != mMaps.end(); ++it)
     {
         if ((*it)->PoiID == PoiID)
         {
@@ -55,19 +58,19 @@ void CPoiToWorld::RemovePoi(uint32 PoiID)
 
 void CPoiToWorld::RemovePoiMeshMap(uint32 PoiID, uint32 ModelID)
 {
-    auto MapIt = mPoiLookupMap.find(PoiID);
-
-    if (MapIt != mPoiLookupMap.end())
+    const auto MapIt = mPoiLookupMap.find(PoiID);
+    if (MapIt == mPoiLookupMap.end())
     {
-        SPoiMap *pMap = MapIt->second;
+        return;
+    }
 
-        for (auto ListIt = pMap->ModelIDs.begin(); ListIt != pMap->ModelIDs.end(); ListIt++)
+    SPoiMap *pMap = MapIt->second;
+    for (auto ListIt = pMap->ModelIDs.begin(); ListIt != pMap->ModelIDs.end(); ++ListIt)
+    {
+        if (*ListIt == ModelID)
         {
-            if (*ListIt == ModelID)
-            {
-                pMap->ModelIDs.erase(ListIt);
-                break;
-            }
+            pMap->ModelIDs.erase(ListIt);
+            break;
         }
     }
 }

--- a/src/Core/Resource/CPoiToWorld.h
+++ b/src/Core/Resource/CPoiToWorld.h
@@ -4,6 +4,7 @@
 #include "CResource.h"
 #include <list>
 #include <map>
+#include <memory>
 #include <vector>
 
 class CPoiToWorld : public CResource
@@ -18,29 +19,29 @@ public:
     };
 
 private:
-    std::vector<SPoiMap*> mMaps;
+    std::vector<std::unique_ptr<SPoiMap>> mMaps;
     std::map<uint32,SPoiMap*> mPoiLookupMap;
 
 public:
-    CPoiToWorld(CResourceEntry *pEntry = 0);
-    ~CPoiToWorld();
+    explicit CPoiToWorld(CResourceEntry *pEntry = nullptr);
+    ~CPoiToWorld() override;
 
     void AddPoi(uint32 PoiID);
     void AddPoiMeshMap(uint32 PoiID, uint32 ModelID);
     void RemovePoi(uint32 PoiID);
     void RemovePoiMeshMap(uint32 PoiID, uint32 ModelID);
 
-    inline uint32 NumMappedPOIs() const
+    uint32 NumMappedPOIs() const
     {
         return mMaps.size();
     }
 
-    inline const SPoiMap* MapByIndex(uint32 Index) const
+    const SPoiMap* MapByIndex(uint32 Index) const
     {
-        return mMaps[Index];
+        return mMaps[Index].get();
     }
 
-    inline const SPoiMap* MapByID(uint32 InstanceID) const
+    const SPoiMap* MapByID(uint32 InstanceID) const
     {
         auto it = mPoiLookupMap.find(InstanceID);
 


### PR DESCRIPTION
Simplifies code related to deallocation.