### PR TITLE
Property: Make use of override where applicable

### DIFF
--- a/src/Core/Resource/Script/Property/CAnimationProperty.h
+++ b/src/Core/Resource/Script/Property/CAnimationProperty.h
@@ -3,24 +3,24 @@
 
 #include "IProperty.h"
 
-class CAnimationProperty : public TSerializeableTypedProperty< uint32, EPropertyType::Animation >
+class CAnimationProperty : public TSerializeableTypedProperty<uint32, EPropertyType::Animation>
 {
     friend class IProperty;
 
 protected:
-    CAnimationProperty(EGame Game)
+    explicit CAnimationProperty(EGame Game)
         : TSerializeableTypedProperty(Game)
     {}
 
 public:
-    virtual void SerializeValue(void* pData, IArchive& rArc) const
+    void SerializeValue(void* pData, IArchive& rArc) const override
     {
-        rArc.SerializePrimitive( (uint32&) ValueRef(pData), SH_HexDisplay );
+        rArc.SerializePrimitive((uint32&)ValueRef(pData), SH_HexDisplay);
     }
 
-    virtual TString ValueAsString(void* pData) const
+    TString ValueAsString(void* pData) const override
     {
-        return TString::HexString( (uint32) Value(pData) );
+        return TString::HexString(static_cast<uint32>(Value(pData)));
     }
 };
 

--- a/src/Core/Resource/Script/Property/CAnimationSetProperty.h
+++ b/src/Core/Resource/Script/Property/CAnimationSetProperty.h
@@ -9,26 +9,26 @@ class CAnimationSetProperty : public TSerializeableTypedProperty< CAnimationPara
     friend class IProperty;
 
 protected:
-    CAnimationSetProperty(EGame Game)
+    explicit CAnimationSetProperty(EGame Game)
         : TSerializeableTypedProperty(Game)
     {
         mDefaultValue.SetGame(Game);
     }
 
 public:
-    virtual void SerializeValue(void* pData, IArchive& Arc) const
+    void SerializeValue(void* pData, IArchive& Arc) const override
     {
         ValueRef(pData).Serialize(Arc);
     }
 
-    virtual const char* HashableTypeName() const
+    const char* HashableTypeName() const override
     {
-        return (Game() <= EGame::Echoes ? "AnimationSet" : "CharacterAnimationSet");
+        return Game() <= EGame::Echoes ? "AnimationSet" : "CharacterAnimationSet";
     }
 
-    virtual CAnimationParameters GetSerializationDefaultValue()
+    CAnimationParameters GetSerializationDefaultValue() override
     {
-        return CAnimationParameters( Game() );
+        return CAnimationParameters(Game());
     }
 };
 

--- a/src/Core/Resource/Script/Property/CAssetProperty.h
+++ b/src/Core/Resource/Script/Property/CAssetProperty.h
@@ -11,44 +11,44 @@ class CAssetProperty : public TSerializeableTypedProperty<CAssetID, EPropertyTyp
     CResTypeFilter mTypeFilter;
 
 protected:
-    CAssetProperty(EGame Game)
+    explicit CAssetProperty(EGame Game)
         : TSerializeableTypedProperty(Game)
     {
         mDefaultValue = CAssetID::InvalidID( mGame );
     }
 
 public:
-    virtual void Serialize(IArchive& rArc)
+    void Serialize(IArchive& rArc) override
     {
         TSerializeableTypedProperty::Serialize(rArc);
         CAssetProperty* pArchetype = static_cast<CAssetProperty*>(mpArchetype);
         rArc << SerialParameter("TypeFilter", mTypeFilter, pArchetype ? SH_Optional : 0, pArchetype ? pArchetype->mTypeFilter : CResTypeFilter());
     }
 
-    virtual bool ShouldSerialize() const
+    bool ShouldSerialize() const override
     {
         CAssetProperty* pArchetype = static_cast<CAssetProperty*>(mpArchetype);
         return TSerializeableTypedProperty::ShouldSerialize() ||
                 mTypeFilter != pArchetype->mTypeFilter;
     }
 
-    virtual void InitFromArchetype(IProperty* pOther)
+    void InitFromArchetype(IProperty* pOther) override
     {
         TTypedProperty::InitFromArchetype(pOther);
         mTypeFilter = static_cast<CAssetProperty*>(pOther)->mTypeFilter;
     }
 
-    virtual void SerializeValue(void* pData, IArchive& Arc) const
+    void SerializeValue(void* pData, IArchive& Arc) const override
     {
         Arc.SerializePrimitive( ValueRef(pData), 0 );
     }
 
-    virtual TString ValueAsString(void* pData) const
+    TString ValueAsString(void* pData) const override
     {
         return Value(pData).ToString();
     }
 
-    virtual CAssetID GetSerializationDefaultValue()
+    CAssetID GetSerializationDefaultValue() override
     {
         return CAssetID::InvalidID(Game());
     }

--- a/src/Core/Resource/Script/Property/CBoolProperty.h
+++ b/src/Core/Resource/Script/Property/CBoolProperty.h
@@ -3,22 +3,22 @@
 
 #include "IProperty.h"
 
-class CBoolProperty : public TSerializeableTypedProperty< bool, EPropertyType::Bool >
+class CBoolProperty : public TSerializeableTypedProperty<bool, EPropertyType::Bool>
 {
     friend class IProperty;
 
 protected:
-    CBoolProperty(EGame Game)
+    explicit CBoolProperty(EGame Game)
         : TSerializeableTypedProperty(Game)
     {}
 
 public:
-    virtual void SerializeValue(void* pData, IArchive& Arc) const
+    void SerializeValue(void* pData, IArchive& Arc) const override
     {
-        Arc.SerializePrimitive( ValueRef(pData), 0 );
+        Arc.SerializePrimitive(ValueRef(pData), 0);
     }
 
-    virtual TString ValueAsString(void* pData)
+    TString ValueAsString(void* pData) const override
     {
         return Value(pData) ? "true" : "false";
     }

--- a/src/Core/Resource/Script/Property/CByteProperty.h
+++ b/src/Core/Resource/Script/Property/CByteProperty.h
@@ -3,24 +3,24 @@
 
 #include "IProperty.h"
 
-class CByteProperty : public TNumericalProperty< int8, EPropertyType::Byte >
+class CByteProperty : public TNumericalProperty<int8, EPropertyType::Byte>
 {
     friend class IProperty;
 
 protected:
-    CByteProperty(EGame Game)
+    explicit CByteProperty(EGame Game)
         : TNumericalProperty(Game)
     {}
 
 public:
-    virtual void SerializeValue(void* pData, IArchive& Arc) const
+    void SerializeValue(void* pData, IArchive& Arc) const override
     {
-        Arc.SerializePrimitive( (int8&) ValueRef(pData), 0 );
+        Arc.SerializePrimitive((int8&)ValueRef(pData), 0);
     }
 
-    virtual TString ValueAsString(void* pData) const
+    TString ValueAsString(void* pData) const override
     {
-        return TString::FromInt32( (int32) Value(pData), 0, 10 );
+        return TString::FromInt32((int32)Value(pData), 0, 10);
     }
 };
 

--- a/src/Core/Resource/Script/Property/CColorProperty.h
+++ b/src/Core/Resource/Script/Property/CColorProperty.h
@@ -4,17 +4,17 @@
 #include "IProperty.h"
 #include "CFloatProperty.h"
 
-class CColorProperty : public TSerializeableTypedProperty< CColor, EPropertyType::Color >
+class CColorProperty : public TSerializeableTypedProperty<CColor, EPropertyType::Color>
 {
     friend class IProperty;
 
 protected:
-    CColorProperty(EGame Game)
+    explicit CColorProperty(EGame Game)
         : TSerializeableTypedProperty(Game)
     {}
 
 public:
-    virtual void PostInitialize()
+    void PostInitialize() override
     {
         CreateIntrinsic(EPropertyType::Float, this, mOffset + 0,  "R");
         CreateIntrinsic(EPropertyType::Float, this, mOffset + 4,  "G");
@@ -23,7 +23,7 @@ public:
         TPropCast<CFloatProperty>( mChildren.back() )->SetDefaultValue(1.0f);
     }
 
-    virtual void SerializeValue(void* pData, IArchive& Arc) const
+    void SerializeValue(void* pData, IArchive& Arc) const override
     {
         ValueRef(pData).Serialize(Arc);
     }

--- a/src/Core/Resource/Script/Property/CEnumProperty.h
+++ b/src/Core/Resource/Script/Property/CEnumProperty.h
@@ -19,19 +19,21 @@ class TEnumPropertyBase : public TSerializeableTypedProperty<int32, TypeEnum>
     struct SEnumValue
     {
         TString Name;
-        uint32 ID;
+        uint32 ID = 0;
 
-        SEnumValue()
-            : ID(0)
-        {}
-
+        SEnumValue() = default;
         SEnumValue(const TString& rkInName, uint32 InID)
             : Name(rkInName), ID(InID) {}
 
 
-        inline bool operator==(const SEnumValue& rkOther) const
+        bool operator==(const SEnumValue& other) const
         {
-            return( Name == rkOther.Name && ID == rkOther.ID );
+            return Name == other.Name && ID == other.ID;
+        }
+
+        bool operator!=(const SEnumValue& other) const
+        {
+            return !operator==(other);
         }
 
         void Serialize(IArchive& rArc)
@@ -47,13 +49,13 @@ class TEnumPropertyBase : public TSerializeableTypedProperty<int32, TypeEnum>
 
 protected:
     /** Constructor */
-    TEnumPropertyBase(EGame Game)
+    explicit TEnumPropertyBase(EGame Game)
         : base(Game)
         , mOverrideTypeName(false)
     {}
 
 public:
-    virtual const char* HashableTypeName() const
+    const char* HashableTypeName() const override
     {
         if (base::mpArchetype)
             return base::mpArchetype->HashableTypeName();
@@ -65,7 +67,7 @@ public:
             return "choice";
     }
 
-    virtual void Serialize(IArchive& rArc)
+    void Serialize(IArchive& rArc) override
     {
         // Skip TSerializeableTypedProperty, serialize default value ourselves so we can set SH_HexDisplay
         TTypedProperty<int32, TypeEnum>::Serialize(rArc);
@@ -87,21 +89,21 @@ public:
         }
     }
 
-    virtual void SerializeValue(void* pData, IArchive& Arc) const
+    void SerializeValue(void* pData, IArchive& Arc) const override
     {
-        Arc.SerializePrimitive( (uint32&) base::ValueRef(pData), 0 );
+        Arc.SerializePrimitive((uint32&)base::ValueRef(pData), 0);
     }
 
-    virtual void InitFromArchetype(IProperty* pOther)
+    void InitFromArchetype(IProperty* pOther) override
     {
         TTypedProperty<int32, TypeEnum>::InitFromArchetype(pOther);
         TEnumPropertyBase* pOtherEnum = static_cast<TEnumPropertyBase*>(pOther);
         mValues = pOtherEnum->mValues;
     }
 
-    virtual TString ValueAsString(void* pData) const
+    TString ValueAsString(void* pData) const override
     {
-        return TString::FromInt32( base::Value(pData), 0, 10 );
+        return TString::FromInt32(base::Value(pData), 0, 10);
     }
 
     void AddValue(TString ValueName, uint32 ValueID)
@@ -109,7 +111,7 @@ public:
         mValues.push_back( SEnumValue(ValueName, ValueID) );
     }
 
-    inline uint32 NumPossibleValues() const { return mValues.size(); }
+    uint32 NumPossibleValues() const { return mValues.size(); }
 
     uint32 ValueIndex(uint32 ID) const
     {
@@ -166,8 +168,8 @@ public:
     }
 };
 
-typedef TEnumPropertyBase<EPropertyType::Choice> CChoiceProperty;
-typedef TEnumPropertyBase<EPropertyType::Enum>   CEnumProperty;
+using CChoiceProperty = TEnumPropertyBase<EPropertyType::Choice>;
+using CEnumProperty = TEnumPropertyBase<EPropertyType::Enum>;
 
 // Specialization of TPropCast to allow interchangeable casting, as both types are the same thing
 template<>

--- a/src/Core/Resource/Script/Property/CFlagsProperty.h
+++ b/src/Core/Resource/Script/Property/CFlagsProperty.h
@@ -10,19 +10,21 @@ class CFlagsProperty : public TSerializeableTypedProperty<uint32, EPropertyType:
     struct SBitFlag
     {
         TString Name;
-        uint32 Mask;
+        uint32 Mask = 0;
 
-        SBitFlag()
-            : Mask(0)
-        {}
-
+        SBitFlag() = default;
         SBitFlag(const TString& rkInName, uint32 InMask)
             : Name(rkInName), Mask(InMask)
         {}
 
-        bool operator==(const SBitFlag& rkOther) const
+        bool operator==(const SBitFlag& other) const
         {
-            return( Name == rkOther.Name && Mask == rkOther.Mask );
+            return Name == other.Name && Mask == other.Mask;
+        }
+
+        bool operator!=(const SBitFlag& other) const
+        {
+            return !operator==(other);
         }
 
         void Serialize(IArchive& rArc)
@@ -32,36 +34,35 @@ class CFlagsProperty : public TSerializeableTypedProperty<uint32, EPropertyType:
         }
     };
     std::vector<SBitFlag> mBitFlags;
-    uint32 mAllFlags;
+    uint32 mAllFlags = 0;
 
-    CFlagsProperty(EGame Game)
+    explicit CFlagsProperty(EGame Game)
         : TSerializeableTypedProperty(Game)
-        , mAllFlags(0)
     {}
 
 public:
-    inline uint32 NumFlags() const
+    uint32 NumFlags() const
     {
         return mBitFlags.size();
     }
 
-    inline TString FlagName(uint32 Idx) const
+    TString FlagName(uint32 Idx) const
     {
         ASSERT(Idx >= 0 && Idx < mBitFlags.size());
         return mBitFlags[Idx].Name;
     }
 
-    inline uint32 FlagMask(uint32 Idx) const
+    uint32 FlagMask(uint32 Idx) const
     {
         ASSERT(Idx >= 0 && Idx < mBitFlags.size());
         return mBitFlags[Idx].Mask;
     }
 
-    virtual void Serialize(IArchive& rArc);
-    virtual void PostInitialize();
-    virtual void SerializeValue(void* pData, IArchive& rArc) const;
-    virtual void InitFromArchetype(IProperty* pOther);
-    virtual TString ValueAsString(void* pData) const;
+    void Serialize(IArchive& rArc) override;
+    void PostInitialize() override;
+    void SerializeValue(void* pData, IArchive& rArc) const override;
+    void InitFromArchetype(IProperty* pOther) override;
+    TString ValueAsString(void* pData) const override;
 
     /**
      * Checks whether there are any unrecognized bits toggled on in the property value.

--- a/src/Core/Resource/Script/Property/CFloatProperty.h
+++ b/src/Core/Resource/Script/Property/CFloatProperty.h
@@ -3,24 +3,24 @@
 
 #include "IProperty.h"
 
-class CFloatProperty : public TNumericalProperty< float, EPropertyType::Float >
+class CFloatProperty : public TNumericalProperty<float, EPropertyType::Float>
 {
     friend class IProperty;
 
 protected:
-    CFloatProperty(EGame Game)
+    explicit CFloatProperty(EGame Game)
         : TNumericalProperty(Game)
     {}
 
 public:
-    virtual void SerializeValue(void* pData, IArchive& Arc) const
+    void SerializeValue(void* pData, IArchive& Arc) const override
     {
-        Arc.SerializePrimitive( (float&) ValueRef(pData), 0 );
+        Arc.SerializePrimitive((float&)ValueRef(pData), 0);
     }
 
-    virtual TString ValueAsString(void* pData) const
+    TString ValueAsString(void* pData) const override
     {
-        return TString::FromFloat( Value(pData) );
+        return TString::FromFloat(Value(pData));
     }
 };
 

--- a/src/Core/Resource/Script/Property/CGuidProperty.h
+++ b/src/Core/Resource/Script/Property/CGuidProperty.h
@@ -3,17 +3,17 @@
 
 #include "IProperty.h"
 
-class CGuidProperty : public TTypedProperty< std::vector<char>, EPropertyType::Guid >
+class CGuidProperty : public TTypedProperty<std::vector<char>, EPropertyType::Guid>
 {
     friend class IProperty;
 
 protected:
-    CGuidProperty(EGame Game)
+    explicit CGuidProperty(EGame Game)
         : TTypedProperty(Game)
     {}
 
 public:
-    virtual void SerializeValue(void* pData, IArchive& Arc) const
+    void SerializeValue(void* pData, IArchive& Arc) const override
     {
         Arc << SerialParameter("Data", ValueRef(pData));
     }

--- a/src/Core/Resource/Script/Property/CIntProperty.h
+++ b/src/Core/Resource/Script/Property/CIntProperty.h
@@ -3,24 +3,24 @@
 
 #include "IProperty.h"
 
-class CIntProperty : public TNumericalProperty< int32, EPropertyType::Int >
+class CIntProperty : public TNumericalProperty<int32, EPropertyType::Int>
 {
     friend class IProperty;
 
 protected:
-    CIntProperty(EGame Game)
+    explicit CIntProperty(EGame Game)
         : TNumericalProperty(Game)
     {}
 
 public:
-    virtual void SerializeValue(void* pData, IArchive& Arc) const
+    void SerializeValue(void* pData, IArchive& Arc) const override
     {
-        Arc.SerializePrimitive( ValueRef(pData), 0 );
+        Arc.SerializePrimitive(ValueRef(pData), 0);
     }
 
-    virtual TString ValueAsString(void* pData) const
+    TString ValueAsString(void* pData) const override
     {
-        return TString::FromInt32( Value(pData), 0, 10 );
+        return TString::FromInt32(Value(pData), 0, 10);
     }
 };
 

--- a/src/Core/Resource/Script/Property/CPointerProperty.h
+++ b/src/Core/Resource/Script/Property/CPointerProperty.h
@@ -7,22 +7,22 @@ class CPointerProperty : public TTypedProperty<void*, EPropertyType::Pointer>
 {
     friend class IProperty;
 
-    CPointerProperty(EGame Game)
+    explicit CPointerProperty(EGame Game)
         : TTypedProperty(Game)
     {}
 
 public:
-    virtual bool IsPointerType() const
+    bool IsPointerType() const override
     {
         return true;
     }
 
-    virtual void* GetChildDataPointer(void* pPropertyData) const
+    void* GetChildDataPointer(void* pPropertyData) const override
     {
         return ValueRef(pPropertyData);
     }
 
-    virtual void SerializeValue(void* pData, IArchive& rArc) const
+    void SerializeValue(void* pData, IArchive& rArc) const override
     {
         // pointers are not serializable, this shouldn't happen
         ASSERT(false);

--- a/src/Core/Resource/Script/Property/CSequenceProperty.h
+++ b/src/Core/Resource/Script/Property/CSequenceProperty.h
@@ -3,16 +3,16 @@
 
 #include "IProperty.h"
 
-class CSequenceProperty : public TTypedProperty< int32, EPropertyType::Sequence >
+class CSequenceProperty : public TTypedProperty<int32, EPropertyType::Sequence>
 {
     friend class IProperty;
 
 protected:
-    CSequenceProperty(EGame Game)
+    explicit CSequenceProperty(EGame Game)
         : TTypedProperty(Game)
     {}
 
-    virtual void SerializeValue(void* pData, IArchive& rArc) const
+    void SerializeValue(void* pData, IArchive& rArc) const override
     {}
 };
 

--- a/src/Core/Resource/Script/Property/CShortProperty.h
+++ b/src/Core/Resource/Script/Property/CShortProperty.h
@@ -8,19 +8,19 @@ class CShortProperty : public TNumericalProperty< int16, EPropertyType::Short >
     friend class IProperty;
 
 protected:
-    CShortProperty(EGame Game)
+    explicit CShortProperty(EGame Game)
         : TNumericalProperty(Game)
     {}
 
 public:
-    virtual void SerializeValue(void* pData, IArchive& Arc) const
+    void SerializeValue(void* pData, IArchive& Arc) const override
     {
-        Arc.SerializePrimitive( ValueRef(pData), 0 );
+        Arc.SerializePrimitive(ValueRef(pData), 0);
     }
 
-    virtual TString ValueAsString(void* pData) const
+    TString ValueAsString(void* pData) const override
     {
-        return TString::FromInt32( (int32) Value(pData), 0, 10 );
+        return TString::FromInt32((int32)Value(pData), 0, 10);
     }
 };
 

--- a/src/Core/Resource/Script/Property/CSoundProperty.h
+++ b/src/Core/Resource/Script/Property/CSoundProperty.h
@@ -3,24 +3,24 @@
 
 #include "IProperty.h"
 
-class CSoundProperty : public TSerializeableTypedProperty< int32, EPropertyType::Sound >
+class CSoundProperty : public TSerializeableTypedProperty<int32, EPropertyType::Sound>
 {
     friend class IProperty;
 
 protected:
-    CSoundProperty(EGame Game)
+    explicit CSoundProperty(EGame Game)
         : TSerializeableTypedProperty(Game)
     {}
 
 public:
-    virtual void SerializeValue(void* pData, IArchive& Arc) const
+    void SerializeValue(void* pData, IArchive& Arc) const override
     {
-        Arc.SerializePrimitive( ValueRef(pData), 0 );
+        Arc.SerializePrimitive(ValueRef(pData), 0);
     }
 
-    virtual TString ValueAsString(void* pData) const
+    TString ValueAsString(void* pData) const override
     {
-        return TString::FromInt32( Value(pData), 0, 10 );
+        return TString::FromInt32(Value(pData), 0, 10);
     }
 };
 

--- a/src/Core/Resource/Script/Property/CSplineProperty.h
+++ b/src/Core/Resource/Script/Property/CSplineProperty.h
@@ -3,17 +3,17 @@
 
 #include "IProperty.h"
 
-class CSplineProperty : public TTypedProperty< std::vector<char>, EPropertyType::Spline >
+class CSplineProperty : public TTypedProperty<std::vector<char>, EPropertyType::Spline>
 {
     friend class IProperty;
 
 protected:
-    CSplineProperty(EGame Game)
+    explicit CSplineProperty(EGame Game)
         : TTypedProperty(Game)
     {}
 
 public:
-    virtual void SerializeValue(void* pData, IArchive& Arc) const
+    void SerializeValue(void* pData, IArchive& Arc) const override
     {
         Arc << SerialParameter("Data", ValueRef(pData));
     }

--- a/src/Core/Resource/Script/Property/CStringProperty.h
+++ b/src/Core/Resource/Script/Property/CStringProperty.h
@@ -3,22 +3,22 @@
 
 #include "IProperty.h"
 
-class CStringProperty : public TSerializeableTypedProperty< TString, EPropertyType::String >
+class CStringProperty : public TSerializeableTypedProperty<TString, EPropertyType::String>
 {
     friend class IProperty;
 
 protected:
-    CStringProperty(EGame Game)
+    explicit CStringProperty(EGame Game)
         : TSerializeableTypedProperty(Game)
     {}
 
 public:
-    virtual void SerializeValue(void* pData, IArchive& Arc) const
+    void SerializeValue(void* pData, IArchive& Arc) const override
     {
-        Arc.SerializePrimitive( ValueRef(pData), 0 );
+        Arc.SerializePrimitive(ValueRef(pData), 0);
     }
 
-    virtual TString ValueAsString(void* pData) const
+    TString ValueAsString(void* pData) const override
     {
         return Value(pData);
     }

--- a/src/Core/Resource/Script/Property/CStructProperty.h
+++ b/src/Core/Resource/Script/Property/CStructProperty.h
@@ -9,30 +9,30 @@ class CStructProperty : public IProperty
 
 public:
     // Must be a valid type for TPropertyRef
-    typedef void* ValueType;
+    using ValueType = void*;
 
 protected:
-    CStructProperty(EGame Game)
+    explicit CStructProperty(EGame Game)
         : IProperty(Game)
     {}
 
 public:
-    virtual EPropertyType Type() const;
-    virtual void PostInitialize();
-    virtual uint32 DataSize() const;
-    virtual uint32 DataAlignment() const;
-    virtual void Construct(void* pData) const;
-    virtual void Destruct(void* pData) const;
-    virtual bool MatchesDefault(void* pData) const;
-    virtual void RevertToDefault(void* pData) const;
-    virtual void SetDefaultFromData(void* pData);
-    virtual const char* HashableTypeName() const;
-    virtual void Serialize(IArchive& rArc);
-    virtual void SerializeValue(void* pData, IArchive& Arc) const;
-    virtual void InitFromArchetype(IProperty* pOther);
-    virtual bool ShouldSerialize() const;
+    EPropertyType Type() const override;
+    void PostInitialize() override;
+    uint32 DataSize() const override;
+    uint32 DataAlignment() const override;
+    void Construct(void* pData) const override;
+    void Destruct(void* pData) const override;
+    bool MatchesDefault(void* pData) const override;
+    void RevertToDefault(void* pData) const override;
+    void SetDefaultFromData(void* pData) override;
+    const char* HashableTypeName() const override;
+    void Serialize(IArchive& rArc) override;
+    void SerializeValue(void* pData, IArchive& Arc) const override;
+    void InitFromArchetype(IProperty* pOther) override;
+    bool ShouldSerialize() const override;
 
-    inline static EPropertyType StaticType() { return EPropertyType::Struct; }
+    static EPropertyType StaticType() { return EPropertyType::Struct; }
 };
 
 #endif

--- a/src/Core/Resource/Script/Property/CVectorProperty.h
+++ b/src/Core/Resource/Script/Property/CVectorProperty.h
@@ -3,29 +3,29 @@
 
 #include "IProperty.h"
 
-class CVectorProperty : public TSerializeableTypedProperty< CVector3f, EPropertyType::Vector >
+class CVectorProperty : public TSerializeableTypedProperty<CVector3f, EPropertyType::Vector>
 {
     friend class IProperty;
 
 protected:
-    CVectorProperty(EGame Game)
+    explicit CVectorProperty(EGame Game)
         : TSerializeableTypedProperty(Game)
     {}
 
 public:
-    virtual void PostInitialize() override
+    void PostInitialize() override
     {
         CreateIntrinsic(EPropertyType::Float, this, mOffset + 0, "X");
         CreateIntrinsic(EPropertyType::Float, this, mOffset + 4, "Y");
         CreateIntrinsic(EPropertyType::Float, this, mOffset + 8, "Z");
     }
 
-    virtual void SerializeValue(void* pData, IArchive& Arc) const override
+    void SerializeValue(void* pData, IArchive& Arc) const override
     {
         ValueRef(pData).Serialize(Arc);
     }
 
-    virtual TString ValueAsString(void* pData) const override
+    TString ValueAsString(void* pData) const override
     {
         return Value(pData).ToString();
     }


### PR DESCRIPTION
Makes the API strongly enforced. This also fixes a bug in CBoolProperty, where ValueAsString() had an incorrect signature (was missing a const).