### PR TITLE
CGameInfo: Make file-scope strings non-allocating

### DIFF
--- a/src/Core/GameProject/CGameInfo.cpp
+++ b/src/Core/GameProject/CGameInfo.cpp
@@ -2,6 +2,9 @@
 #include "CResourceStore.h"
 #include <Common/FileUtil.h>
 
+constexpr char gkGameInfoDir[] = "resources/gameinfo";
+constexpr char gkGameInfoExt[] = "xml";
+
 bool CGameInfo::LoadGameInfo(EGame Game)
 {
     Game = RoundGame(Game);
@@ -85,4 +88,9 @@ TString CGameInfo::GetDefaultGameInfoPath(EGame Game)
 
     TString GameName = GetGameShortName(Game);
     return TString::Format("%s/%s/GameInfo%s.%s", *gDataDir, *gkGameInfoDir, *GameName, *gkGameInfoExt);
+}
+
+TString CGameInfo::GetExtension()
+{
+    return gkGameInfoExt;
 }

--- a/src/Core/GameProject/CGameInfo.h
+++ b/src/Core/GameProject/CGameInfo.h
@@ -8,9 +8,6 @@
 #include <Common/Serialization/XML.h>
 #include <map>
 
-const TString gkGameInfoDir = "resources/gameinfo";
-const TString gkGameInfoExt = "xml";
-
 //@todo merge this class into CGameTemplate
 // they serve similar purposes, no real reason for them to be different classes
 class CGameInfo
@@ -50,14 +47,14 @@ public:
     TString GetAreaName(const CAssetID& rkID) const;
 
     // Accessors
-    inline EGame Game() const   { return mGame; }
+    EGame Game() const   { return mGame; }
 
     // Static
     static CGameInfo* GetGameInfo(EGame Game);
     static EGame RoundGame(EGame Game);
     static TString GetDefaultGameInfoPath(EGame Game);
 
-    inline static TString GetExtension()    { return gkGameInfoExt; }
+    static TString GetExtension();
 };
 
 #endif // CGAMEINFO


### PR DESCRIPTION
Same behavior, minus any potential heap allocations and static constructors.