### PR TITLE
CIndexBuffer: Mark member functions as const where applicable

### DIFF
--- a/src/Core/OpenGL/CIndexBuffer.cpp
+++ b/src/Core/OpenGL/CIndexBuffer.cpp
@@ -79,17 +79,17 @@ void CIndexBuffer::DrawElements(uint Offset, uint Size)
     Unbind();
 }
 
-bool CIndexBuffer::IsBuffered()
+bool CIndexBuffer::IsBuffered() const
 {
     return mBuffered;
 }
 
-uint CIndexBuffer::GetSize()
+uint CIndexBuffer::GetSize() const
 {
     return mIndices.size();
 }
 
-GLenum CIndexBuffer::GetPrimitiveType()
+GLenum CIndexBuffer::GetPrimitiveType() const
 {
     return mPrimitiveType;
 }

--- a/src/Core/OpenGL/CIndexBuffer.h
+++ b/src/Core/OpenGL/CIndexBuffer.h
@@ -25,10 +25,10 @@ public:
     void Unbind();
     void DrawElements();
     void DrawElements(uint Offset, uint Size);
-    bool IsBuffered();
+    bool IsBuffered() const;
 
-    uint GetSize();
-    GLenum GetPrimitiveType();
+    uint GetSize() const;
+    GLenum GetPrimitiveType() const;
     void SetPrimitiveType(GLenum Type);
 
     void TrianglesToStrips(uint16 *pIndices, uint Count);


### PR DESCRIPTION
These member functions don't alter internal state, so we can mark them as const.