### PR TITLE
Update dependencies

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,28 +1,28 @@
 ﻿{
-	"configurations": [
-		{
-			"name": "x64-Debug",
-			"generator": "Ninja",
-			"configurationType": "Debug",
-			"inheritEnvironments": [ "msvc_x64_x64" ],
-			"buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
-			"installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-			"cmakeCommandArgs": "-DCMAKE_PREFIX_PATH=C:/Qt/5.14.1/msvc2017_64/lib/cmake/Qt5",
-			"buildCommandArgs": "",
+  "configurations": [
+    {
+      "name": "x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+      "cmakeCommandArgs": "-DCMAKE_PREFIX_PATH=C:/Qt/5.14.2/msvc2017_64/lib/cmake/Qt5",
+      "buildCommandArgs": "",
 			"ctestCommandArgs": "",
 			"variables": []
-		},
-		{
-			"name": "x64-Release",
-			"generator": "Ninja",
-			"configurationType": "RelWithDebInfo",
-			"inheritEnvironments": [ "msvc_x64_x64" ],
-			"buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
-			"installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-			"cmakeCommandArgs": "-DCMAKE_PREFIX_PATH=C:/Qt/5.14.1/msvc2017_64/lib/cmake/Qt5",
-			"buildCommandArgs": "",
+    },
+    {
+      "name": "x64-Release",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+      "cmakeCommandArgs": "-DCMAKE_PREFIX_PATH=C:/Qt/5.14.2/msvc2017_64/lib/cmake/Qt5",
+      "buildCommandArgs": "",
 			"ctestCommandArgs": "",
 			"variables": []
-		}
-	]
+    }
+  ]
 }

--- a/dewfile.json
+++ b/dewfile.json
@@ -13,7 +13,7 @@
             "url": "https://github.com/assimp/assimp",
             "type": "git",
             "head": "master",
-            "ref": "83237de02ffb97305317d24564c44ce4794af3db",
+            "ref": "c305b50f13627befade833cef8399be3c53fc4ec",
             "dependson": [
                 "zlib"
             ],

--- a/src/Core/CMakeLists.txt
+++ b/src/Core/CMakeLists.txt
@@ -11,9 +11,6 @@ find_package(assimp CONFIG REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(Threads REQUIRED)
 
-# AssImp's cmake config is pretty awful. It doesn't include necesary libraries. Hopefully this can be fixed later.
-find_library(IIRXML_LIBRARY NAMES IrrXMLd IrrXML)
-
 file(GLOB_RECURSE source_files
     "*.c"
     "*.cpp"
@@ -41,7 +38,6 @@ target_link_libraries(
     OpenGL::GL
     assimp::assimp
     Threads::Threads
-    ${IIRXML_LIBRARY}
     ${ZLIB_LIBRARY}
 )
 


### PR DESCRIPTION
Fixes a Windows build issue with AssImp (and removes an unnecessary CMake dependency), as well as fixing a crash on project load due to MP1R templates. Also updated Qt 5.14 to the latest patch release.