### PR TITLE
General: Update to Qt6

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -7,7 +7,7 @@
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
       "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-      "cmakeCommandArgs": "-DCMAKE_PREFIX_PATH=C:/Qt/5.14.2/msvc2017_64/lib/cmake/Qt5",
+      "cmakeCommandArgs": "-DCMAKE_PREFIX_PATH=C:/Qt/6.10.1/msvc2022_64/lib/cmake/Qt6",
       "buildCommandArgs": "",
 			"ctestCommandArgs": "",
 			"variables": []
@@ -19,7 +19,7 @@
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
       "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-      "cmakeCommandArgs": "-DCMAKE_PREFIX_PATH=C:/Qt/5.14.2/msvc2017_64/lib/cmake/Qt5",
+      "cmakeCommandArgs": "-DCMAKE_PREFIX_PATH=C:/Qt/6.10.1/msvc2022_64/lib/cmake/Qt6",
       "buildCommandArgs": "",
 			"ctestCommandArgs": "",
 			"variables": []

--- a/README.md
+++ b/README.md
@@ -13,20 +13,20 @@ by running `git submodule update --init --recursive`.
 
 **64-bit Note:** Except for Visual Studio and the Qt installer, ensure 64-bit (x86-64, x64) packages are installed.
 
-* [Visual Studio 2017](https://visualstudio.microsoft.com/vs/) (Desktop development with C++)
-* [Qt 5.10+](https://download.qt.io/official_releases/qt/) (MSVC 2017 64-bit specification)
+* [Visual Studio 2022](https://visualstudio.microsoft.com/vs/) (Desktop development with C++)
+* [Qt 6.5+](https://download.qt.io/official_releases/qt/) (MSVC 2022 64-bit specification)
 * [LLVM 6.0.1 x86-64](http://releases.llvm.org/6.0.1/LLVM-6.0.1-win64.exe) installation; currently must be installed to `C:\Program Files\LLVM\`
 * [Python 3 x86-64](https://www.python.org/downloads/windows/)
 
 ## Build using Qt Creator
 
 **Compiler Note:** Before starting, it is wise to select the 64-bit compiler by opening *Tools* > *Kits* > *Kits* tab.
-The C and C++ compilers should be set to *Microsoft Visual C++ Compiler 15.0 (amd64)*.
+The C and C++ compilers should be set to *Visual Studio Community 2022 (amd64)*.
 
 **CMake Note:** At the time of writing, Qt Creator will search for a user-installed CMake but this is not necessary. 
 The CMake that comes with Visual Studio may be manually selected by opening *Tools* > *Kits* > *CMake* tab, then adding
 a manual CMake with the path:
-`C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe`.
+`C:\Program Files (x86)\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe`.
 
 **Debugger Note:** To use Qt Creator for debugging, *Debugging Tools for Windows* must be installed from the
 [Windows SDK package](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk). Once installed,
@@ -42,7 +42,7 @@ the Qt Creator kit should automatically detect CDB. Make sure the x64 version is
 ## Build using Visual Studio
 
 **Qt Note:** It may be necessary to edit both CMAKE_PREFIX_PATH entries in the *CMakeSettings.json* file.
-They should be set to `C:/Qt/<QT VERSION>/msvc2017_64/lib/cmake/Qt5`.
+They should be set to `C:/Qt/<QT VERSION>/msvc2022_64/lib/cmake/Qt6`.
 
 1. *File* > *Open* > *CMake*
 2. Select *CMakeLists.txt* at root of cloned PrimeWorldEditor
@@ -51,11 +51,11 @@ They should be set to `C:/Qt/<QT VERSION>/msvc2017_64/lib/cmake/Qt5`.
 
 ## Build using Command Line
 
-1. Launch *x64 Native Tools Command Prompt for VS 2017*
+1. Launch *x64 Native Tools Command Prompt for VS 2022*
 2. `cd <PATH TO PrimeWorldEditor ROOT>`
 3. `mkdir build`
 4. `cd build`
-5. `cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=C:/Qt/<QT VERSION>/msvc2017_64/lib/cmake/Qt5 ..`
+5. `cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=C:/Qt/<QT VERSION>/msvc2022_64/lib/cmake/Qt6 ..`
 6. `ninja`
 7. *PrimeWorldEditor.exe* is found in the `build/bin` directory.
 
@@ -64,7 +64,7 @@ They should be set to `C:/Qt/<QT VERSION>/msvc2017_64/lib/cmake/Qt5`.
 ## Requirements
 
 * [Xcode 10.2+](https://developer.apple.com/xcode/)
-* [Qt 5.10+](https://download.qt.io/official_releases/qt/) (macOS specification)
+* [Qt 6.5+](https://download.qt.io/official_releases/qt/) (macOS specification)
 * *cmake*, *ninja* and *python* installed using [Homebrew](https://brew.sh/)
 
 ## Build using Xcode
@@ -72,7 +72,7 @@ They should be set to `C:/Qt/<QT VERSION>/msvc2017_64/lib/cmake/Qt5`.
 1. `cd <PATH TO PrimeWorldEditor ROOT>`
 2. `mkdir build`
 3. `cd build`
-4. `cmake -G Xcode -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=~/Qt/<QT VERSION>/clang_64/lib/cmake/Qt5 ..`
+4. `cmake -G Xcode -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=~/Qt/<QT VERSION>/clang_64/lib/cmake/Qt6 ..`
 5. Open *PrimeWorldEditor.xcodeproj*
 6. Edit/Build/Debug/Run
 
@@ -81,7 +81,7 @@ They should be set to `C:/Qt/<QT VERSION>/msvc2017_64/lib/cmake/Qt5`.
 1. `cd <PATH TO PrimeWorldEditor ROOT>`
 2. `mkdir build`
 3. `cd build`
-4. `cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=~/Qt/<QT VERSION>/clang_64/lib/cmake/Qt5 ..`
+4. `cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=~/Qt/<QT VERSION>/clang_64/lib/cmake/Qt6 ..`
 5. `ninja`
 6. *PrimeWorldEditor.app* is found in the `build/bin` directory.
 
@@ -90,7 +90,7 @@ They should be set to `C:/Qt/<QT VERSION>/msvc2017_64/lib/cmake/Qt5`.
 ## Requirements
 
 * A working compiler toolchain (GCC or Clang)
-* *cmake*, *ninja*, *python3*, *qt5* (dev), *clang* (dev) packages
+* *cmake*, *ninja*, *python3*, *qt6* (dev), *clang* (dev) packages
 
 ## Build using Command Line
 

--- a/src/Editor/CBasicViewport.cpp
+++ b/src/Editor/CBasicViewport.cpp
@@ -96,7 +96,7 @@ void CBasicViewport::mousePressEvent(QMouseEvent *pEvent)
         OnMouseClick(pEvent);
     }
 
-    mLastMousePos = pEvent->globalPos();
+    mLastMousePos = pEvent->globalPosition().toPoint();
 }
 
 void CBasicViewport::mouseReleaseEvent(QMouseEvent *pEvent)
@@ -117,7 +117,7 @@ void CBasicViewport::mouseReleaseEvent(QMouseEvent *pEvent)
     // Send context menu event to subclass if needed
     if ((pEvent->button() == Qt::RightButton) && (mMoveTimer.Time() <= 0.3) && !mMouseMoved)
     {
-        QContextMenuEvent Event(QContextMenuEvent::Mouse, QCursor::pos());
+        QContextMenuEvent Event(QContextMenuEvent::Mouse, QCursor::pos(), QCursor::pos());
         this->ContextMenu(&Event);
     }
  }

--- a/src/Editor/CEditorApplication.cpp
+++ b/src/Editor/CEditorApplication.cpp
@@ -18,7 +18,7 @@
 #include <Core/GameProject/CGameProject.h>
 
 #include <QFuture>
-#include <QtConcurrent/QtConcurrentRun>
+#include <QtConcurrentRun>
 
 CEditorApplication::CEditorApplication(int& rArgc, char **ppArgv)
     : QApplication(rArgc, ppArgv)
@@ -280,7 +280,7 @@ bool CEditorApplication::RebuildResourceDatabase()
         Dialog.SetOneShotTask("Rebuilding resource database");
         Dialog.DisallowCanceling();
 
-        QFuture<void> Future = QtConcurrent::run(pProj->ResourceStore(), &CResourceStore::RebuildFromDirectory);
+        QFuture<void> Future = QtConcurrent::run(&CResourceStore::RebuildFromDirectory, pProj->ResourceStore());
         Dialog.WaitForResults(Future);
         Dialog.close();
 

--- a/src/Editor/CExportGameDialog.cpp
+++ b/src/Editor/CExportGameDialog.cpp
@@ -14,7 +14,7 @@
 #include <QFileDialog>
 #include <QLabel>
 #include <QVBoxLayout>
-#include <QtConcurrent/QtConcurrentRun>
+#include <QtConcurrentRun>
 
 #include <nod/nod.hpp>
 
@@ -445,7 +445,7 @@ void CExportGameDialog::Export()
     StrExportDir.EnsureEndsWith('/');
 
     CProgressDialog Dialog(tr("Creating new game project"), false, true, parentWidget());
-    QFuture<bool> Future = QtConcurrent::run(mpExporter.get(), &CGameExporter::Export, mpDisc.get(), StrExportDir, &NameMap, &GameInfo, &Dialog);
+    QFuture<bool> Future = QtConcurrent::run(&CGameExporter::Export, mpExporter.get(), mpDisc.get(), StrExportDir, &NameMap, &GameInfo, &Dialog);
     mExportSuccess = Dialog.WaitForResults(Future);
 
     if (!mExportSuccess)

--- a/src/Editor/CGeneratePropertyNamesDialog.h
+++ b/src/Editor/CGeneratePropertyNamesDialog.h
@@ -36,7 +36,7 @@ class CGeneratePropertyNamesDialog : public QDialog
     CProgressBarNotifier mNotifier;
 
     /** List of ID/type pairs in the ID pool */
-    QVector<SPropertyIdTypePair> mIdPairs;
+    QList<SPropertyIdTypePair> mIdPairs;
 
     /** Future/future watcher for name generation task */
     QFuture<void> mFuture;
@@ -46,7 +46,7 @@ class CGeneratePropertyNamesDialog : public QDialog
     QTimer mUpdateTimer;
 
     /** Checked items in the output tree widget */
-    QVector<QTreeWidgetItem*> mCheckedItems;
+    QList<QTreeWidgetItem*> mCheckedItems;
 
     /** Whether name generation is running */
     bool mRunningNameGeneration = false;

--- a/src/Editor/CGizmo.cpp
+++ b/src/Editor/CGizmo.cpp
@@ -6,7 +6,6 @@
 #include <Common/Log.h>
 
 #include <QApplication>
-#include <QDesktopWidget>
 #include <QScreen>
 
 CGizmo::CGizmo()

--- a/src/Editor/CMakeLists.txt
+++ b/src/Editor/CMakeLists.txt
@@ -54,12 +54,7 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 
-if (WIN32)
-    set(QT_PLATFORM_COMPONENTS WinExtras)
-    set(QT_PLATFORM_COMPONENTS_LIBS Qt5::WinExtras)
-endif()
-
-find_package(Qt5 COMPONENTS Core Widgets ${QT_PLATFORM_COMPONENTS} REQUIRED)
+find_package(Qt6 COMPONENTS Concurrent Core Gui OpenGL OpenGLWidgets Widgets REQUIRED)
 
 file(GLOB_RECURSE source_files
     "*.cpp"
@@ -109,8 +104,13 @@ target_compile_features(pwe_editor PRIVATE cxx_std_17)
 target_link_libraries(
     pwe_editor
     pwe_core
-    Qt5::Widgets
-    ${QT_PLATFORM_COMPONENTS_LIBS}
+    Qt6::Concurrent
+    Qt6::Core
+    Qt6::Gui
+    Qt6::OpenGL
+    Qt6::OpenGLWidgets
+    Qt6::Widgets
+
     ${PLAT_LIBS}
 )
 
@@ -154,7 +154,7 @@ if (WIN32 OR APPLE)
 endif()
 
 if (WIN32)
-    find_program(WINDEPLOYQT_PROGRAM windeployqt PATHS ${Qt5_DIR}/../../../bin/)
+    find_program(WINDEPLOYQT_PROGRAM windeployqt PATHS ${Qt6_DIR}/../../../bin/)
     if(WINDEPLOYQT_PROGRAM)
         message(STATUS "Found ${WINDEPLOYQT_PROGRAM}")
     else()
@@ -163,7 +163,7 @@ if (WIN32)
 
     # run windeployqt to gather necessary qt libraries and plugins
     add_custom_command(TARGET pwe_editor POST_BUILD COMMAND ${WINDEPLOYQT_PROGRAM} ARGS
-                       --no-angle --no-opengl-sw $<TARGET_FILE:pwe_editor>)
+                       $<TARGET_FILE:pwe_editor>)
 
     # copy bin directory of dew prefix
     add_custom_command(TARGET pwe_editor POST_BUILD COMMAND ${CMAKE_COMMAND} ARGS -E copy_directory
@@ -174,7 +174,7 @@ if (WIN32)
     install(DIRECTORY "${CMAKE_SOURCE_DIR}/resources" DESTINATION ".")
     install(DIRECTORY "${CMAKE_SOURCE_DIR}/templates" DESTINATION ".")
 elseif (APPLE)
-    find_program(MACDEPLOYQT_PROGRAM macdeployqt PATHS ${Qt5_DIR}/../../../bin/)
+    find_program(MACDEPLOYQT_PROGRAM macdeployqt PATHS ${Qt6_DIR}/../../../bin/)
     if(MACDEPLOYQT_PROGRAM)
         message(STATUS "Found ${MACDEPLOYQT_PROGRAM}")
     else()

--- a/src/Editor/CProgressDialog.cpp
+++ b/src/Editor/CProgressDialog.cpp
@@ -14,24 +14,6 @@ CProgressDialog::CProgressDialog(QString OperationName, bool UseBusyIndicator, b
     mpUI->ProgressBar->setMaximum(UseBusyIndicator ? 0 : 10000);
     setWindowTitle(OperationName);
 
-#ifdef WIN32
-    QWinTaskbarButton *pButton = new QWinTaskbarButton(this);
-    QWindow *pWindow = UICommon::FindWidgetWindowHandle( parentWidget() );
-
-    if (pWindow)
-    {
-        pButton->setWindow(pWindow);
-        mpTaskbarProgress = pButton->progress();
-        mpTaskbarProgress->setMinimum(0);
-        mpTaskbarProgress->setMaximum(UseBusyIndicator ? 0 : 10000);
-        mpTaskbarProgress->show();
-    }
-    else
-        mpTaskbarProgress = nullptr;
-    
-    setWindowFlags(windowFlags() | Qt::MSWindowsFixedSizeDialogHint);
-#endif
-
     connect(mpUI->CancelButton, &QPushButton::pressed, this, &CProgressDialog::CancelButtonClicked);
 }
 
@@ -57,14 +39,6 @@ void CProgressDialog::closeEvent(QCloseEvent *pEvent)
     else
     {
         pEvent->accept();
-
-#ifdef WIN32
-        if (mpTaskbarProgress)
-        {
-            mpTaskbarProgress->reset();
-            mpTaskbarProgress->hide();
-        }
-#endif
     }
 }
 
@@ -102,10 +76,5 @@ void CProgressDialog::UpdateUI(const QString& rkTaskDesc, const QString& rkStepD
     {
         int ProgressValue = 10000 * ProgressPercent;
         mpUI->ProgressBar->setValue(ProgressValue);
-
-#ifdef WIN32
-        if (mpTaskbarProgress)
-            mpTaskbarProgress->setValue(ProgressValue);
-#endif
     }
 }

--- a/src/Editor/CProgressDialog.h
+++ b/src/Editor/CProgressDialog.h
@@ -10,11 +10,6 @@
 #include <QFuture>
 #include <QFutureWatcher>
 
-#ifdef WIN32
-#include <QtWinExtras/QWinTaskbarButton>
-#include <QtWinExtras/QWinTaskbarProgress>
-#endif
-
 #include <memory>
 
 namespace Ui {
@@ -29,10 +24,6 @@ class CProgressDialog : public IProgressNotifierUI
     bool mAlertOnFinish;
     bool mFinished = false;
     bool mCanceled = false;
-
-#ifdef WIN32
-    QWinTaskbarProgress *mpTaskbarProgress;
-#endif
 
 public:
     explicit CProgressDialog(QString OperationName, bool UseBusyIndicator, bool AlertOnFinish, QWidget *pParent = nullptr);

--- a/src/Editor/CProjectSettingsDialog.cpp
+++ b/src/Editor/CProjectSettingsDialog.cpp
@@ -16,7 +16,7 @@
 #include <QFuture>
 #include <QFutureWatcher>
 #include <QMessageBox>
-#include <QtConcurrent/QtConcurrentRun>
+#include <QtConcurrentRun>
 
 CProjectSettingsDialog::CProjectSettingsDialog(QWidget *pParent)
     : QDialog(pParent)
@@ -191,12 +191,12 @@ void CProjectSettingsDialog::BuildISO()
 
             if (!NeedsDiscMerge)
             {
-                QFuture<bool> Future = QtConcurrent::run(pProj, &CGameProject::BuildISO, TO_TSTRING(IsoPath), &Dialog);
+                QFuture<bool> Future = QtConcurrent::run(&CGameProject::BuildISO, pProj, TO_TSTRING(IsoPath), &Dialog);
                 Success = Dialog.WaitForResults(Future);
             }
             else
             {
-                QFuture<bool> Future = QtConcurrent::run(pProj, &CGameProject::MergeISO, TO_TSTRING(IsoPath), (nod::DiscWii*) pBaseDisc.get(), &Dialog);
+                QFuture<bool> Future = QtConcurrent::run(&CGameProject::MergeISO, pProj, TO_TSTRING(IsoPath), (nod::DiscWii*)pBaseDisc.get(), &Dialog);
                 Success = Dialog.WaitForResults(Future);
             }
 

--- a/src/Editor/CharacterEditor/CSkeletonHierarchyModel.cpp
+++ b/src/Editor/CharacterEditor/CSkeletonHierarchyModel.cpp
@@ -74,7 +74,7 @@ QVariant CSkeletonHierarchyModel::data(const QModelIndex& rkIndex, int Role) con
         return TO_QSTRING(pBone->Name());
     }
 
-    return QVariant::Invalid;
+    return QVariant();
 }
 
 CBone* CSkeletonHierarchyModel::BoneForIndex(const QModelIndex& rkIndex) const

--- a/src/Editor/IEditor.cpp
+++ b/src/Editor/IEditor.cpp
@@ -48,7 +48,7 @@ bool IEditor::CheckUnsavedChanges()
 
     if (!OkToClear)
     {
-        const int Result = QMessageBox::warning(this, tr("Save"), tr("You have unsaved changes. Save?"), QMessageBox::Yes, QMessageBox::No, QMessageBox::Cancel);
+        const int Result = QMessageBox::warning(this, tr("Save"), tr("You have unsaved changes. Save?"), QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel, QMessageBox::Cancel);
 
         if (Result == QMessageBox::Yes)
         {

--- a/src/Editor/NDolphinIntegration.cpp
+++ b/src/Editor/NDolphinIntegration.cpp
@@ -4,8 +4,8 @@
 #include "Editor/SDolHeader.h"
 
 #include <QFileInfo>
-#include <QRegExp>
 #include <QObject>
+#include <QOverload>
 #include <QSettings>
 
 #undef CopyFile
@@ -37,10 +37,10 @@ CGameProject* gpQuickplayProject = nullptr;
 void CQuickplayRelay::QuickplayStarted()
 {
     debugf("Quickplay session started.");
-    connect(gpDolphinProcess, qOverload<int>(&QProcess::finished), this, &CQuickplayRelay::QuickplayFinished);
+    connect(gpDolphinProcess, &QProcess::finished, this, &CQuickplayRelay::QuickplayFinished);
 }
 
-void CQuickplayRelay::QuickplayFinished(int ReturnCode)
+void CQuickplayRelay::QuickplayFinished(int ReturnCode, QProcess::ExitStatus exitStatus)
 {
     debugf("Quickplay session finished.");
     disconnect(gpDolphinProcess, 0, this, 0);

--- a/src/Editor/NDolphinIntegration.h
+++ b/src/Editor/NDolphinIntegration.h
@@ -92,7 +92,7 @@ public:
 
 public slots:
     void QuickplayStarted();
-    void QuickplayFinished(int ReturnCode);
+    void QuickplayFinished(int ReturnCode, QProcess::ExitStatus exitStatus);
 };
 
 /** Attempt to launch quickplay based on the current editor state. */

--- a/src/Editor/PropertyEdit/CPropertyModel.cpp
+++ b/src/Editor/PropertyEdit/CPropertyModel.cpp
@@ -220,13 +220,14 @@ QVariant CPropertyModel::headerData(int Section, Qt::Orientation Orientation, in
         if (Section == 0) return tr("Name");
         if (Section == 1) return tr("Value");
     }
-    return QVariant::Invalid;
+
+    return QVariant();
 }
 
 QVariant CPropertyModel::data(const QModelIndex& rkIndex, int Role) const
 {
     if (!rkIndex.isValid())
-        return QVariant::Invalid;
+        return QVariant();
 
     if (Role == Qt::DisplayRole || (Role == Qt::ToolTipRole && rkIndex.column() == 1))
     {
@@ -465,7 +466,7 @@ QVariant CPropertyModel::data(const QModelIndex& rkIndex, int Role) const
         }
     }
 
-    return QVariant::Invalid;
+    return QVariant();
 }
 
 QModelIndex CPropertyModel::index(int Row, int Column, const QModelIndex& rkParent) const

--- a/src/Editor/ResourceBrowser/CResourceDelegate.cpp
+++ b/src/Editor/ResourceBrowser/CResourceDelegate.cpp
@@ -82,7 +82,7 @@ void CResourceBrowserDelegate::paint(QPainter *pPainter, const QStyleOptionViewI
     // Draw icon
     QVariant IconVariant = rkIndex.model()->data(rkIndex, Qt::DecorationRole);
 
-    if (IconVariant != QVariant::Invalid)
+    if (IconVariant.isValid())
     {
         QIcon Icon = IconVariant.value<QIcon>();
         Icon.paint(pPainter, GeomInfo.IconRect);

--- a/src/Editor/ResourceBrowser/CResourceTableModel.cpp
+++ b/src/Editor/ResourceBrowser/CResourceTableModel.cpp
@@ -2,6 +2,8 @@
 #include "CResourceBrowser.h"
 #include "CResourceMimeData.h"
 
+#include <algorithm>
+
 CResourceTableModel::CResourceTableModel(CResourceBrowser *pBrowser, QObject *pParent)
     : QAbstractTableModel(pParent)
 {
@@ -27,7 +29,7 @@ int CResourceTableModel::columnCount(const QModelIndex&) const
 QVariant CResourceTableModel::data(const QModelIndex& rkIndex, int Role) const
 {
     if (rkIndex.column() != 0)
-        return QVariant::Invalid;
+        return QVariant();
 
     // Directory
     if (IsIndexDirectory(rkIndex))
@@ -44,7 +46,7 @@ QVariant CResourceTableModel::data(const QModelIndex& rkIndex, int Role) const
         if (Role == Qt::DecorationRole)
             return QIcon(QStringLiteral(":/icons/Open_24px.svg"));
 
-        return QVariant::Invalid;
+        return QVariant();
     }
 
     // Resource
@@ -59,7 +61,7 @@ QVariant CResourceTableModel::data(const QModelIndex& rkIndex, int Role) const
     if (Role == Qt::DecorationRole)
         return QIcon(QStringLiteral(":/icons/Sphere Preview.svg"));
 
-    return QVariant::Invalid;
+    return QVariant();
 }
 
 Qt::ItemFlags CResourceTableModel::flags(const QModelIndex& rkIndex) const
@@ -277,7 +279,7 @@ void CResourceTableModel::RecursiveAddDirectoryContents(CVirtualDirectory *pDir)
 
 int CResourceTableModel::EntryListIndex(CResourceEntry *pEntry)
 {
-    return qLowerBound(mEntries, pEntry) - mEntries.constBegin();
+    return std::lower_bound(mEntries.begin(), mEntries.end(), pEntry) - mEntries.begin();
 }
 
 void CResourceTableModel::RefreshAllIndices()

--- a/src/Editor/ResourceBrowser/CVirtualDirectoryModel.cpp
+++ b/src/Editor/ResourceBrowser/CVirtualDirectoryModel.cpp
@@ -73,7 +73,7 @@ int CVirtualDirectoryModel::columnCount(const QModelIndex&) const
 QVariant CVirtualDirectoryModel::data(const QModelIndex& rkIndex, int Role) const
 {
     if (!rkIndex.isValid())
-        return QVariant::Invalid;
+        return QVariant();
 
     if (Role == Qt::DisplayRole || Role == Qt::ToolTipRole)
     {
@@ -94,7 +94,7 @@ QVariant CVirtualDirectoryModel::data(const QModelIndex& rkIndex, int Role) cons
         return QIcon(QStringLiteral(":/icons/Open_24px.svg"));
     }
 
-    return QVariant::Invalid;
+    return QVariant();
 }
 
 bool CVirtualDirectoryModel::setData(const QModelIndex& rkIndex, const QVariant& rkValue, int Role)

--- a/src/Editor/StringEditor/CStringListModel.cpp
+++ b/src/Editor/StringEditor/CStringListModel.cpp
@@ -39,7 +39,7 @@ QVariant CStringListModel::data(const QModelIndex& kIndex, int Role) const
 {
     if (!kIndex.isValid() || !mpStringTable)
     {
-        return QVariant::Invalid;
+        return QVariant();
     }
 
     const auto StringIndex = static_cast<size_t>(kIndex.row());
@@ -66,7 +66,7 @@ QVariant CStringListModel::data(const QModelIndex& kIndex, int Role) const
     // other roles: invalid
     else
     {
-        return QVariant::Invalid;
+        return QVariant();
     }
 }
 

--- a/src/Editor/Widgets/CFilteredResourceModel.h
+++ b/src/Editor/Widgets/CFilteredResourceModel.h
@@ -83,7 +83,7 @@ public:
             }
         }
 
-        return QVariant::Invalid;
+        return QVariant();
     }
 
     // Accessors

--- a/src/Editor/Widgets/CSelectResourcePanel.cpp
+++ b/src/Editor/Widgets/CSelectResourcePanel.cpp
@@ -2,8 +2,8 @@
 #include "ui_CSelectResourcePanel.h"
 #include "Editor/CEditorApplication.h"
 #include <Common/Math/MathUtil.h>
-#include <QDesktopWidget>
 #include <QDebug>
+#include <QScreen>
 
 CSelectResourcePanel::CSelectResourcePanel(CResourceSelector *pSelector)
     : QFrame(pSelector)
@@ -24,7 +24,7 @@ CSelectResourcePanel::CSelectResourcePanel(CResourceSelector *pSelector)
 
     // Determine size
     QPoint SelectorPos = pSelector->parentWidget()->mapToGlobal( pSelector->pos() );
-    QRect ScreenRect = gpEdApp->desktop()->availableGeometry();
+    QRect ScreenRect = gpEdApp->primaryScreen()->availableGeometry();
 
     int MaxWidthLeft = SelectorPos.x();
     int MaxWidthRight = ScreenRect.width() - SelectorPos.x() - pSelector->width();

--- a/src/Editor/Widgets/WColorPicker.cpp
+++ b/src/Editor/Widgets/WColorPicker.cpp
@@ -59,7 +59,9 @@ void WColorPicker::mousePressEvent(QMouseEvent *)
 
 void WColorPicker::mouseReleaseEvent(QMouseEvent *pEvent)
 {
-    if ((pEvent->x() < width()) && (pEvent->y() < height()))
+    const auto pos = pEvent->position().toPoint();
+
+    if (pos.x() < width() && pos.y() < height())
     {
         mOldColor = mColor;
 

--- a/src/Editor/Widgets/WDraggableSpinBox.cpp
+++ b/src/Editor/Widgets/WDraggableSpinBox.cpp
@@ -1,6 +1,5 @@
 #include "WDraggableSpinBox.h"
 #include <QApplication>
-#include <QDesktopWidget>
 #include <QLineEdit>
 #include <QMouseEvent>
 #include <QScreen>
@@ -35,7 +34,9 @@ void WDraggableSpinBox::mouseReleaseEvent(QMouseEvent *pEvent)
     {
         if (!mBeenDragged)
         {
-            if (pEvent->y() <= height() / 2)
+            const auto pos = pEvent->position().toPoint();
+
+            if (pos.y() <= height() / 2)
                 stepUp();
             else
                 stepDown();

--- a/src/Editor/WorldEditor/CInstancesModel.cpp
+++ b/src/Editor/WorldEditor/CInstancesModel.cpp
@@ -49,7 +49,7 @@ CInstancesModel::~CInstancesModel() = default;
 
 QVariant CInstancesModel::headerData(int Section, Qt::Orientation Orientation, int Role) const
 {
-    if ((Orientation == Qt::Horizontal) && (Role == Qt::DisplayRole))
+    if (Orientation == Qt::Horizontal && Role == Qt::DisplayRole)
     {
         switch (Section)
         {
@@ -59,7 +59,8 @@ QVariant CInstancesModel::headerData(int Section, Qt::Orientation Orientation, i
         case 3: return tr("Show");
         }
     }
-    return QVariant::Invalid;
+
+    return QVariant();
 }
 
 QModelIndex CInstancesModel::index(int Row, int Column, const QModelIndex& rkParent) const
@@ -154,7 +155,7 @@ QModelIndex CInstancesModel::parent(const QModelIndex& rkChild) const
         {
             CScriptTemplate *pTemp = pObj->Template();
 
-            for (size_t iTemp = 0; iTemp < mTemplateList.size(); iTemp++)
+            for (qsizetype iTemp = 0; iTemp < mTemplateList.size(); iTemp++)
             {
                 if (mTemplateList[iTemp] == pTemp)
                     return createIndex(static_cast<int>(iTemp), 0, static_cast<quintptr>((iTemp << TYPES_ROW_INDEX_SHIFT) | 1));
@@ -221,7 +222,7 @@ QVariant CInstancesModel::data(const QModelIndex& rkIndex, int Role) const
             if (rkIndex.column() == 0)
                 return mBaseItems[rkIndex.row()];
 
-            return QVariant::Invalid;
+            return QVariant();
         }
 
         // Object types
@@ -236,7 +237,7 @@ QVariant CInstancesModel::data(const QModelIndex& rkIndex, int Role) const
             }
 
             // todo: show/hide button in column 2
-            return QVariant::Invalid;
+            return QVariant();
         }
 
         // Instances
@@ -260,7 +261,7 @@ QVariant CInstancesModel::data(const QModelIndex& rkIndex, int Role) const
             }
             else
             {
-                return QVariant::Invalid;
+                return QVariant();
             }
         }
     }
@@ -269,7 +270,7 @@ QVariant CInstancesModel::data(const QModelIndex& rkIndex, int Role) const
     else if ((Role == Qt::DecorationRole) && (rkIndex.column() == 3))
     {
         if (!mpScene)
-            return QVariant::Invalid;
+            return QVariant();
 
         static const QIcon Visible(QStringLiteral(":/icons/Show.svg"));
         static const QIcon Invisible(QStringLiteral(":/icons/Hide.svg"));
@@ -321,7 +322,7 @@ QVariant CInstancesModel::data(const QModelIndex& rkIndex, int Role) const
         }
     }
 
-    return QVariant::Invalid;
+    return QVariant();
 }
 
 void CInstancesModel::SetModelType(EInstanceModelType Type)
@@ -493,7 +494,8 @@ void CInstancesModel::PropertyModified(IProperty *pProp, CScriptObject *pInst)
         const uint32 Index = mTemplateList.indexOf(pInst->Template());
         const QModelIndex TempIndex = index(Index, 0, ScriptRoot);
 
-        const QList<CScriptObject*> InstList = QList<CScriptObject*>::fromStdList(pInst->Template()->ObjectList());
+        const auto& ObjList = pInst->Template()->ObjectList();
+        const QList<CScriptObject*> InstList(ObjList.begin(), ObjList.end());
         const uint32 InstIdx = InstList.indexOf(pInst);
         const QModelIndex InstIndex = index(InstIdx, 0, TempIndex);
         emit dataChanged(InstIndex, InstIndex);

--- a/src/Editor/WorldEditor/CLayerModel.cpp
+++ b/src/Editor/WorldEditor/CLayerModel.cpp
@@ -19,7 +19,7 @@ QVariant CLayerModel::data(const QModelIndex &index, int role) const
     if (mpArea && (role == Qt::DisplayRole) && (index.row() < rowCount(QModelIndex())))
         return TO_QSTRING(Layer(index)->Name());
 
-    return QVariant::Invalid;
+    return QVariant();
 }
 
 void CLayerModel::SetArea(CGameArea *pArea)

--- a/src/Editor/WorldEditor/CLinkModel.cpp
+++ b/src/Editor/WorldEditor/CLinkModel.cpp
@@ -36,7 +36,7 @@ int CLinkModel::columnCount(const QModelIndex& /*rkParent*/) const
 QVariant CLinkModel::data(const QModelIndex& rkIndex, int Role) const
 {
     if (!mpObject)
-        return QVariant::Invalid;
+        return QVariant();
 
     if (Role == Qt::DisplayRole || Role == Qt::ToolTipRole)
     {
@@ -76,11 +76,11 @@ QVariant CLinkModel::data(const QModelIndex& rkIndex, int Role) const
         }
 
         default:
-            return QVariant::Invalid;
+            return QVariant();
         }
     }
 
-    return QVariant::Invalid;
+    return QVariant();
 }
 
 QVariant CLinkModel::headerData(int Section, Qt::Orientation Orientation, int Role) const
@@ -92,9 +92,9 @@ QVariant CLinkModel::headerData(int Section, Qt::Orientation Orientation, int Ro
         case 0: return (mType == ELinkType::Incoming ? tr("Sender") : tr("Target"));
         case 1: return tr("State");
         case 2: return tr("Message");
-        default: return QVariant::Invalid;
+        default: return QVariant();
         }
     }
 
-    return QVariant::Invalid;
+    return QVariant();
 }

--- a/src/Editor/WorldEditor/CPoiListDialog.h
+++ b/src/Editor/WorldEditor/CPoiListDialog.h
@@ -48,7 +48,8 @@ public:
 
     QVariant data(const QModelIndex& rkIndex, int Role) const override
     {
-        if (!rkIndex.isValid()) return QVariant::Invalid;
+        if (!rkIndex.isValid())
+            return QVariant();
 
         if (Role == Qt::DisplayRole)
             return TO_QSTRING(mObjList[rkIndex.row()]->Instance()->InstanceName());
@@ -65,7 +66,7 @@ public:
                 return QIcon(QStringLiteral(":/icons/POI Normal.svg"));
         }
 
-        return QVariant::Invalid;
+        return QVariant();
     }
 
     CScriptNode* PoiForIndex(const QModelIndex& rkIndex) const

--- a/src/Editor/WorldEditor/CPoiMapModel.cpp
+++ b/src/Editor/WorldEditor/CPoiMapModel.cpp
@@ -13,10 +13,12 @@ CPoiMapModel::CPoiMapModel(CWorldEditor *pEditor, QObject *pParent)
 
 QVariant CPoiMapModel::headerData(int Section, Qt::Orientation Orientation, int Role) const
 {
-    if (Section == 0 && Orientation == Qt::Horizontal && Role == Qt::DisplayRole)
-        return tr("PointOfInterest");
-
-    return QVariant::Invalid;
+    if (Section == 0 && Orientation == Qt::Horizontal)
+    {
+        if (Role == Qt::DisplayRole)
+            return tr("PointOfInterest");
+    }
+    return QVariant();
 }
 
 int CPoiMapModel::rowCount(const QModelIndex& /*rkParent*/) const
@@ -59,7 +61,7 @@ QVariant CPoiMapModel::data(const QModelIndex& rkIndex, int Role) const
         }
     }
 
-    return QVariant::Invalid;
+    return QVariant();
 }
 
 void CPoiMapModel::AddPOI(CScriptNode *pPOI)

--- a/src/Editor/WorldEditor/CStateMessageModel.h
+++ b/src/Editor/WorldEditor/CStateMessageModel.h
@@ -57,7 +57,7 @@ public:
             return mEntries[rkIndex.row()].Name;
         }
 
-        return QVariant::Invalid;
+        return QVariant();
     }
 
     void SetGameTemplate(CGameTemplate *pGame)

--- a/src/Editor/WorldEditor/CTemplateListView.h
+++ b/src/Editor/WorldEditor/CTemplateListView.h
@@ -28,8 +28,8 @@ public:
     {
         if (Role == Qt::DisplayRole || Role == Qt::ToolTipRole)
             return TO_QSTRING(mTemplates[rkIndex.row()]->Name());
-        else
-            return QVariant::Invalid;
+
+        return QVariant();
     }
 
     Qt::DropActions supportedDropActions() const override

--- a/src/Editor/WorldEditor/CWorldEditor.cpp
+++ b/src/Editor/WorldEditor/CWorldEditor.cpp
@@ -92,7 +92,7 @@ CWorldEditor::CWorldEditor(QWidget *parent)
 
     // Initialize edit mode toolbar
     mpEditModeButtonGroup = new QButtonGroup(this);
-    connect(mpEditModeButtonGroup, SIGNAL(buttonClicked(int)), this, SLOT(ChangeEditMode(int)));
+    connect(mpEditModeButtonGroup, &QButtonGroup::idClicked, this, qOverload<int>(&CWorldEditor::ChangeEditMode));
 
     AddEditModeButton(QIcon(QStringLiteral(":/icons/World.svg")), tr("Edit World Info"), eWEM_EditWorldInfo);
     AddEditModeButton(QIcon(QStringLiteral(":/icons/Modify.svg")), tr("Edit Script"), eWEM_EditScript);
@@ -131,7 +131,7 @@ CWorldEditor::CWorldEditor(QWidget *parent)
     mpQuickplayAction->setVisible(false);
     mpQuickplayAction->setEnabled(false);
 
-    connect(pQuickplayButton, SIGNAL(pressed()), this, SLOT(LaunchQuickplay()));
+    connect(pQuickplayButton, &QToolButton::pressed, this, &CWorldEditor::LaunchQuickplay);
 
     // "Open Recent" menu
     mpOpenRecentMenu = new QMenu(this);
@@ -142,7 +142,7 @@ CWorldEditor::CWorldEditor(QWidget *parent)
         QAction *pAction = new QAction(this);
         pAction->setVisible(false);
         pAction->setData((int) iAct);
-        connect(pAction, SIGNAL(triggered(bool)), this, SLOT(OpenRecentProject()));
+        connect(pAction, &QAction::triggered, this, &CWorldEditor::OpenRecentProject);
 
         mpOpenRecentMenu->addAction(pAction);
         mRecentProjectsActions[iAct] = pAction;
@@ -150,69 +150,69 @@ CWorldEditor::CWorldEditor(QWidget *parent)
     UpdateOpenRecentActions();
 
     // Connect signals and slots
-    connect(gpEdApp, SIGNAL(ActiveProjectChanged(CGameProject*)), this, SLOT(OnActiveProjectChanged(CGameProject*)));
-    connect(gpEdApp->clipboard(), SIGNAL(dataChanged()), this, SLOT(OnClipboardDataModified()));
+    connect(gpEdApp, &CEditorApplication::ActiveProjectChanged, this, &CWorldEditor::OnActiveProjectChanged);
+    connect(gpEdApp->clipboard(), &QClipboard::dataChanged, this, &CWorldEditor::OnClipboardDataModified);
 
-    connect(ui->MainViewport, SIGNAL(ViewportClick(SRayIntersection,QMouseEvent*)), this, SLOT(OnViewportClick(SRayIntersection,QMouseEvent*)));
-    connect(ui->MainViewport, SIGNAL(InputProcessed(SRayIntersection,QMouseEvent*)), this, SLOT(OnViewportInputProcessed(SRayIntersection,QMouseEvent*)));
-    connect(ui->MainViewport, SIGNAL(InputProcessed(SRayIntersection,QMouseEvent*)), this, SLOT(UpdateGizmoUI()) );
-    connect(ui->MainViewport, SIGNAL(InputProcessed(SRayIntersection,QMouseEvent*)), this, SLOT(UpdateStatusBar()) );
-    connect(ui->MainViewport, SIGNAL(InputProcessed(SRayIntersection,QMouseEvent*)), this, SLOT(UpdateCursor()) );
-    connect(ui->MainViewport, SIGNAL(GizmoMoved()), this, SLOT(OnGizmoMoved()));
-    connect(ui->MainViewport, SIGNAL(CameraOrbit()), this, SLOT(UpdateCameraOrbit()));
-    connect(this, SIGNAL(SelectionModified()), this, SLOT(OnSelectionModified()));
-    connect(this, SIGNAL(SelectionTransformed()), this, SLOT(UpdateCameraOrbit()));
-    connect(this, SIGNAL(PickModeEntered(QCursor)), this, SLOT(OnPickModeEnter(QCursor)));
-    connect(this, SIGNAL(PickModeExited()), this, SLOT(OnPickModeExit()));
-    connect(ui->TransformSpinBox, SIGNAL(ValueChanged(CVector3f)), this, SLOT(OnTransformSpinBoxModified(CVector3f)));
-    connect(ui->TransformSpinBox, SIGNAL(EditingDone(CVector3f)), this, SLOT(OnTransformSpinBoxEdited(CVector3f)));
-    connect(ui->CamSpeedSpinBox, SIGNAL(valueChanged(double)), this, SLOT(OnCameraSpeedChange(double)));
-    connect(&UndoStack(), SIGNAL(indexChanged(int)), this, SLOT(OnUndoStackIndexChanged()));
+    connect(ui->MainViewport, &CSceneViewport::ViewportClick, this, &CWorldEditor::OnViewportClick);
+    connect(ui->MainViewport, &CSceneViewport::InputProcessed, this, &CWorldEditor::OnViewportInputProcessed);
+    connect(ui->MainViewport, &CSceneViewport::InputProcessed, this, &CWorldEditor::UpdateGizmoUI);
+    connect(ui->MainViewport, &CSceneViewport::InputProcessed, this, &CWorldEditor::UpdateStatusBar);
+    connect(ui->MainViewport, &CSceneViewport::InputProcessed, this, &CWorldEditor::UpdateCursor);
+    connect(ui->MainViewport, &CSceneViewport::GizmoMoved, this, &CWorldEditor::OnGizmoMoved);
+    connect(ui->MainViewport, &CSceneViewport::CameraOrbit, this, &CWorldEditor::UpdateCameraOrbit);
+    connect(this, &CWorldEditor::SelectionModified, this, &CWorldEditor::OnSelectionModified);
+    connect(this, &CWorldEditor::SelectionTransformed, this, &CWorldEditor::UpdateCameraOrbit);
+    connect(this, &CWorldEditor::PickModeEntered, this, &CWorldEditor::OnPickModeEnter);
+    connect(this, &CWorldEditor::PickModeExited, this, &CWorldEditor::OnPickModeExit);
+    connect(ui->TransformSpinBox, &WVectorEditor::ValueChanged, this, &CWorldEditor::OnTransformSpinBoxModified);
+    connect(ui->TransformSpinBox, &WVectorEditor::EditingDone, this, &CWorldEditor::OnTransformSpinBoxEdited);
+    connect(ui->CamSpeedSpinBox, &WDraggableSpinBox::valueChanged, this, &CWorldEditor::OnCameraSpeedChange);
+    connect(&UndoStack(), &QUndoStack::indexChanged, this, &CWorldEditor::OnUndoStackIndexChanged);
 
-    connect(ui->ActionOpenProject, SIGNAL(triggered()), this, SLOT(OpenProject()));
-    connect(ui->ActionSave, SIGNAL(triggered()) , this, SLOT(Save()));
-    connect(ui->ActionSaveAndRepack, SIGNAL(triggered()), this, SLOT(SaveAndRepack()));
-    connect(ui->ActionExportGame, SIGNAL(triggered()), this, SLOT(ExportGame()));
-    connect(ui->ActionProjectSettings, SIGNAL(triggered()), this, SLOT(OpenProjectSettings()));
-    connect(ui->ActionCloseProject, SIGNAL(triggered()), this, SLOT(CloseProject()));
-    connect(ui->ActionExit, SIGNAL(triggered()), this, SLOT(close()));
+    connect(ui->ActionOpenProject, &QAction::triggered, this, &CWorldEditor::OpenProject);
+    connect(ui->ActionSave, &QAction::triggered , this, &CWorldEditor::Save);
+    connect(ui->ActionSaveAndRepack, &QAction::triggered, this, &CWorldEditor::SaveAndRepack);
+    connect(ui->ActionExportGame, &QAction::triggered, this, &CWorldEditor::ExportGame);
+    connect(ui->ActionProjectSettings, &QAction::triggered, this, &CWorldEditor::OpenProjectSettings);
+    connect(ui->ActionCloseProject, &QAction::triggered, this, &CWorldEditor::CloseProject);
+    connect(ui->ActionExit, &QAction::triggered, this, &CWorldEditor::close);
 
-    connect(ui->ActionCut, SIGNAL(triggered()), this, SLOT(Cut()));
-    connect(ui->ActionCopy, SIGNAL(triggered()), this, SLOT(Copy()));
-    connect(ui->ActionPaste, SIGNAL(triggered()), this, SLOT(Paste()));
-    connect(ui->ActionDelete, SIGNAL(triggered()), this, SLOT(DeleteSelection()));
-    connect(ui->ActionSelectAll, SIGNAL(triggered()), this, SLOT(SelectAllTriggered()));
-    connect(ui->ActionInvertSelection, SIGNAL(triggered()), this, SLOT(InvertSelectionTriggered()));
-    connect(ui->ActionLink, SIGNAL(toggled(bool)), this, SLOT(OnLinkButtonToggled(bool)));
-    connect(ui->ActionUnlink, SIGNAL(triggered()), this, SLOT(OnUnlinkClicked()));
+    connect(ui->ActionCut, &QAction::triggered, this, &CWorldEditor::Cut);
+    connect(ui->ActionCopy, &QAction::triggered, this, &CWorldEditor::Copy);
+    connect(ui->ActionPaste, &QAction::triggered, this, &CWorldEditor::Paste);
+    connect(ui->ActionDelete, &QAction::triggered, this, &CWorldEditor::DeleteSelection);
+    connect(ui->ActionSelectAll, &QAction::triggered, this, &CWorldEditor::SelectAllTriggered);
+    connect(ui->ActionInvertSelection, &QAction::triggered, this, &CWorldEditor::InvertSelectionTriggered);
+    connect(ui->ActionLink, &QAction::toggled, this, &CWorldEditor::OnLinkButtonToggled);
+    connect(ui->ActionUnlink, &QAction::triggered, this, &CWorldEditor::OnUnlinkClicked);
 
-    connect(ui->ActionEditTweaks, SIGNAL(triggered()), mpTweakEditor, SLOT(show()));
-    connect(ui->ActionEditLayers, SIGNAL(triggered()), this, SLOT(EditLayers()));
+    connect(ui->ActionEditTweaks, &QAction::triggered, mpTweakEditor, &CWorldEditor::show);
+    connect(ui->ActionEditLayers, &QAction::triggered, this, &CWorldEditor::EditLayers);
     if (gTemplatesWritable)
-        connect(ui->ActionGeneratePropertyNames, SIGNAL(triggered()), mpGeneratePropertyNamesDialog, SLOT(show()));
+        connect(ui->ActionGeneratePropertyNames, &QAction::triggered, mpGeneratePropertyNamesDialog, &CWorldEditor::show);
     else
         ui->ActionGeneratePropertyNames->setEnabled(false);
 
-    connect(ui->ActionDrawWorld, SIGNAL(triggered()), this, SLOT(ToggleDrawWorld()));
-    connect(ui->ActionDrawObjects, SIGNAL(triggered()), this, SLOT(ToggleDrawObjects()));
-    connect(ui->ActionDrawCollision, SIGNAL(triggered()), this, SLOT(ToggleDrawCollision()));
-    connect(ui->ActionDrawObjectCollision, SIGNAL(triggered()), this, SLOT(ToggleDrawObjectCollision()));
-    connect(ui->ActionDrawLights, SIGNAL(triggered()), this, SLOT(ToggleDrawLights()));
-    connect(ui->ActionDrawSky, SIGNAL(triggered()), this, SLOT(ToggleDrawSky()));
-    connect(ui->ActionGameMode, SIGNAL(triggered()), this, SLOT(ToggleGameMode()));
-    connect(ui->ActionDisableAlpha, SIGNAL(triggered()), this, SLOT(ToggleDisableAlpha()));
-    connect(ui->ActionNoLighting, SIGNAL(triggered()), this, SLOT(SetNoLighting()));
-    connect(ui->ActionBasicLighting, SIGNAL(triggered()), this, SLOT(SetBasicLighting()));
-    connect(ui->ActionWorldLighting, SIGNAL(triggered()), this, SLOT(SetWorldLighting()));
-    connect(ui->ActionNoBloom, SIGNAL(triggered()), this, SLOT(SetNoBloom()));
-    connect(ui->ActionBloomMaps, SIGNAL(triggered()), this, SLOT(SetBloomMaps()));
-    connect(ui->ActionFakeBloom, SIGNAL(triggered()), this, SLOT(SetFakeBloom()));
-    connect(ui->ActionBloom, SIGNAL(triggered()), this, SLOT(SetBloom()));
-    connect(ui->ActionIncrementGizmo, SIGNAL(triggered()), this, SLOT(IncrementGizmo()));
-    connect(ui->ActionDecrementGizmo, SIGNAL(triggered()), this, SLOT(DecrementGizmo()));
-    connect(ui->ActionCollisionRenderSettings, SIGNAL(triggered()), mpCollisionDialog, SLOT(show()));
+    connect(ui->ActionDrawWorld, &QAction::triggered, this, &CWorldEditor::ToggleDrawWorld);
+    connect(ui->ActionDrawObjects, &QAction::triggered, this, &CWorldEditor::ToggleDrawObjects);
+    connect(ui->ActionDrawCollision, &QAction::triggered, this, &CWorldEditor::ToggleDrawCollision);
+    connect(ui->ActionDrawObjectCollision, &QAction::triggered, this, &CWorldEditor::ToggleDrawObjectCollision);
+    connect(ui->ActionDrawLights, &QAction::triggered, this, &CWorldEditor::ToggleDrawLights);
+    connect(ui->ActionDrawSky, &QAction::triggered, this, &CWorldEditor::ToggleDrawSky);
+    connect(ui->ActionGameMode, &QAction::triggered, this, &CWorldEditor::ToggleGameMode);
+    connect(ui->ActionDisableAlpha, &QAction::triggered, this, &CWorldEditor::ToggleDisableAlpha);
+    connect(ui->ActionNoLighting, &QAction::triggered, this, &CWorldEditor::SetNoLighting);
+    connect(ui->ActionBasicLighting, &QAction::triggered, this, &CWorldEditor::SetBasicLighting);
+    connect(ui->ActionWorldLighting, &QAction::triggered, this, &CWorldEditor::SetWorldLighting);
+    connect(ui->ActionNoBloom, &QAction::triggered, this, &CWorldEditor::SetNoBloom);
+    connect(ui->ActionBloomMaps, &QAction::triggered, this, &CWorldEditor::SetBloomMaps);
+    connect(ui->ActionFakeBloom, &QAction::triggered, this, &CWorldEditor::SetFakeBloom);
+    connect(ui->ActionBloom, &QAction::triggered, this, &CWorldEditor::SetBloom);
+    connect(ui->ActionIncrementGizmo, &QAction::triggered, this, &CWorldEditor::IncrementGizmo);
+    connect(ui->ActionDecrementGizmo, &QAction::triggered, this, &CWorldEditor::DecrementGizmo);
+    connect(ui->ActionCollisionRenderSettings, &QAction::triggered, mpCollisionDialog, &CWorldEditor::show);
 
-    connect(ui->ActionAbout, SIGNAL(triggered(bool)), this, SLOT(About()));
+    connect(ui->ActionAbout, &QAction::triggered, this, &CWorldEditor::About);
 }
 
 CWorldEditor::~CWorldEditor()
@@ -1056,8 +1056,8 @@ void CWorldEditor::OnLinkButtonToggled(bool Enabled)
     if (Enabled)
     {
         EnterPickMode(ENodeType::Script, true, false, false);
-        connect(this, SIGNAL(PickModeClick(SRayIntersection,QMouseEvent*)), this, SLOT(OnLinkClick(SRayIntersection)));
-        connect(this, SIGNAL(PickModeExited()), this, SLOT(OnLinkEnd()));
+        connect(this, &CWorldEditor::PickModeClick, this, &CWorldEditor::OnLinkClick);
+        connect(this, &CWorldEditor::PickModeExited, this, &CWorldEditor::OnLinkEnd);
         mIsMakingLink = true;
         mpNewLinkSender = nullptr;
         mpNewLinkReceiver = nullptr;
@@ -1088,8 +1088,8 @@ void CWorldEditor::OnLinkClick(const SRayIntersection& rkIntersect)
 
 void CWorldEditor::OnLinkEnd()
 {
-    disconnect(this, SIGNAL(PickModeClick(SRayIntersection,QMouseEvent*)), this, SLOT(OnLinkClick(SRayIntersection)));
-    disconnect(this, SIGNAL(PickModeExited()), this, SLOT(OnLinkEnd()));
+    disconnect(this, &CWorldEditor::PickModeClick, this, &CWorldEditor::OnLinkClick);
+    disconnect(this, &CWorldEditor::PickModeExited, this, &CWorldEditor::OnLinkEnd);
     ui->ActionLink->setChecked(false);
     mIsMakingLink = false;
     mpNewLinkSender = nullptr;

--- a/src/Editor/WorldEditor/CWorldInfoSidebar.ui
+++ b/src/Editor/WorldEditor/CWorldInfoSidebar.ui
@@ -112,9 +112,9 @@
         <property name="sortingEnabled">
          <bool>true</bool>
         </property>
-        <attribute name="headerVisible">
+        <property name="headerHidden">
          <bool>false</bool>
-        </attribute>
+        </property>
        </widget>
       </item>
      </layout>

--- a/src/Editor/WorldEditor/CWorldTreeModel.cpp
+++ b/src/Editor/WorldEditor/CWorldTreeModel.cpp
@@ -99,7 +99,7 @@ QVariant CWorldTreeModel::data(const QModelIndex& rkIndex, int Role) const
         static const QIcon sAreaIcon  = QIcon(QStringLiteral(":/icons/New_16px.svg"));
 
         if (rkIndex.column() == 1)
-            return QVariant::Invalid;
+            return QVariant();
         else if (IndexIsWorld(rkIndex))
             return sWorldIcon;
         else
@@ -144,7 +144,7 @@ QVariant CWorldTreeModel::data(const QModelIndex& rkIndex, int Role) const
         return Font;
     }
 
-    return QVariant::Invalid;
+    return QVariant();
 }
 
 QVariant CWorldTreeModel::headerData(int Section, Qt::Orientation Orientation, int Role) const
@@ -156,7 +156,7 @@ QVariant CWorldTreeModel::headerData(int Section, Qt::Orientation Orientation, i
         else
             return tr("Internal Name");
     }
-    return QVariant::Invalid;
+    return QVariant();
 }
 
 bool CWorldTreeModel::IndexIsWorld(const QModelIndex& rkIndex) const

--- a/src/Editor/WorldEditor/WInstancesTab.ui
+++ b/src/Editor/WorldEditor/WInstancesTab.ui
@@ -68,6 +68,9 @@
          <property name="sortingEnabled">
           <bool>true</bool>
          </property>
+         <property name="headerHidden">
+          <bool>false</bool>
+         </property>
         </widget>
        </item>
       </layout>


### PR DESCRIPTION
Migrate over to Qt 6 so that we can keep the UI toolkit pegged at the current major version and keep up with API changes.

Unfortunately this also means we have to gut a small feature in the progress dialogs, since the extras module doesn't exist in Qt6 anymore.

Few things of note (to clarify why some things were changed):

---
- `QVector<>` is internally an alias of QList now, so any changeover is due to that to make the semantics a little clearer. Every instance of this isn't touched, but only the ones related to the initial porting to Qt6 (the rest can be touched later, since nothing is broken through using the old name).

- QtConcurrent requires arguments to be swapped on some invocations, and discarding instances need to use the global thread pool instead.

- `fromStdList()`, etc are removed can be replaced with range constructors.

- `--no-angle` and other commands are removed from newer versions of windeployqt, so they can be removed.

- QMouseEvent's `x()` and `y()` members are deprecated. Instead we access them via `position()`.

- `qLowerBound` is removed (with documentation recommending the use of `std::lower_bound` instead).

- Migrated a lot of remaining old-style signal/slots over to the newer way of binding functions directly. We had a few cases where we were binding to signals that didn't exist anymore (but were silently ignored, due to the use of SIGNAL).

- `QVariant::Invalid` (and other type IDs) are deprecated and also break existing functionality. Instead we can return default constructed QVariants where applicable, which restores functionality that would be broken if left as is (e.g. many list would straight up not populate or have wonky size hinting).<br>
The reason for this is that the `QVariant(QVariant::Type)` constructor models a unique kind of internal QVariant state where it's considered to be in an invalid state, but accessing the (supposedly) invalid state will instead return a default constructed value of the internal type.<br>
This kinda sucks because this means genuinely invalid states that would warrant an assertion or other type of error would be silently ignored and execution would continue on as normal, so changing this over also enforces correctness a little bit (on top of, well, fixing all the broken UI controls).

---

Just a general note that this has only been thoroughly tested on Windows, so it'd be nice to get someone on Linux to give it a whirl. I have a few other changes to PWE (and some bugs I'd like to hunt down), but I'd like to keep those until after landing Qt 6 compatibility, since (imo) it's the more important thing when it comes to forward compatibility and ease of use.