### PR TITLE
Add editing support for GUID properties

### DIFF
--- a/src/Core/Resource/Script/Property/CGuidProperty.h
+++ b/src/Core/Resource/Script/Property/CGuidProperty.h
@@ -3,6 +3,9 @@
 
 #include "Core/Resource/Script/Property/IProperty.h"
 #include <vector>
+#include <ranges>
+#include <fmt/format.h>
+#include <fmt/ranges.h>
 
 class CGuidProperty : public TTypedProperty<std::vector<char>, EPropertyType::Guid>
 {
@@ -18,6 +21,22 @@ public:
     {
         Arc << SerialParameter("Data", ValueRef(pData));
     }
+
+    TString ValueAsString(const void* pData) const override
+    {
+        // Display as mixed-endian
+        constexpr auto to_hex = [](char c)
+        {
+            return fmt::format("{:02x}", static_cast<unsigned char>(c));
+        };
+        return fmt::format("{}-{}-{}-{}-{}", 
+            fmt::join(std::vector<char>{Value(pData)[3], Value(pData)[2], Value(pData)[1], Value(pData)[0]} | std::views::transform(to_hex), ""),
+            fmt::join(std::vector<char>{Value(pData)[5], Value(pData)[4]} | std::views::transform(to_hex), ""),
+            fmt::join(std::vector<char>{Value(pData)[7], Value(pData)[6]} | std::views::transform(to_hex), ""),
+            fmt::join(std::vector<char>{Value(pData)[8], Value(pData)[9]} | std::views::transform(to_hex), ""),
+            fmt::join(std::vector<char>{Value(pData)[10], Value(pData)[11], Value(pData)[12], Value(pData)[13], Value(pData)[14], Value(pData)[15]} | std::views::transform(to_hex), "")
+        );
+    };
 };
 
-#endif // CSPLINEPROPERTY_H
+#endif // CGUIDPROPERTY_H

--- a/src/Editor/PropertyEdit/CPropertyDelegate.cpp
+++ b/src/Editor/PropertyEdit/CPropertyDelegate.cpp
@@ -19,6 +19,7 @@
 #include <QComboBox>
 #include <QEvent>
 #include <QLineEdit>
+#include <QUuid>
 
 #include <concepts>
 #include <memory>
@@ -122,6 +123,7 @@ QWidget* CPropertyDelegate::createEditor(QWidget* pParent, const QStyleOptionVie
         }
 
         case EPropertyType::String:
+        case EPropertyType::Guid:
         {
             auto* pLineEdit = new QLineEdit(pParent);
             ConnectRelay(this, pLineEdit, rkIndex, &QLineEdit::textEdited);
@@ -303,6 +305,18 @@ void CPropertyDelegate::setEditorData(QWidget *pEditor, const QModelIndex &rkInd
                     break;
                 }
 
+                case EPropertyType::Guid:
+                {
+                    auto* pLineEdit = static_cast<QLineEdit*>(pEditor);
+
+                    if (!pLineEdit->hasFocus())
+                    {
+                        pLineEdit->setText(TO_QSTRING(pProp->ValueAsString(pData)));
+                    }
+
+                    break;
+                }
+
                 case EPropertyType::Enum:
                 case EPropertyType::Choice:
                 {
@@ -473,6 +487,22 @@ void CPropertyDelegate::setModelData(QWidget *pEditor, QAbstractItemModel* /*pMo
                     auto* pLineEdit = static_cast<const QLineEdit*>(pEditor);
                     auto* pString = static_cast<CStringProperty*>(pProp);
                     pString->ValueRef(pData) = TO_TSTRING(pLineEdit->text());
+                    break;
+                }
+
+                case EPropertyType::Guid:
+                {
+                    auto* pLineEdit = static_cast<const QLineEdit*>(pEditor);
+                    auto* pGuid = static_cast<CGuidProperty*>(pProp);
+                    auto gBytes = QUuid(pLineEdit->text()).toRfc4122();
+                    // Convert from big-endian to mixed-endian
+                    pGuid->ValueRef(pData) = std::vector<char>{
+                        gBytes[3], gBytes[2], gBytes[1], gBytes[0],
+                        gBytes[5], gBytes[4],
+                        gBytes[7], gBytes[6],
+                        gBytes[8], gBytes[9],
+                        gBytes[10], gBytes[11], gBytes[12], gBytes[13], gBytes[14], gBytes[15]
+                    };
                     break;
                 }
 


### PR DESCRIPTION
Adds viewing and editing support for GUID properties, which previously displayed only as a blank row.

Example:
<img width="431" height="196" alt="image" src="https://github.com/user-attachments/assets/963b72e0-e155-4ea0-a4a3-b2d48fb52961" />

Also updated the templates submodule to latest, since prior to now we haven't had any templates using GUID properties.