### PR TITLE
Add some null checks

### DIFF
--- a/src/Core/Scene/CSceneNode.cpp
+++ b/src/Core/Scene/CSceneNode.cpp
@@ -141,22 +141,24 @@ void CSceneNode::BuildLightList(CGameArea *pArea)
     const size_t NumLights = pArea->NumLights(Index);
     if (NumLights == 0)
         mAmbientColor = CColor::TransparentWhite();
-
-    for (auto& light : pArea->Lights(Index))
+    else // This else ensures we don't call pArea->Lights on an out-of-bounds index
     {
-        // Ambient lights should only be present one per layer; need to check how the game deals with multiple ambients
-        if (light.Type() == ELightType::LocalAmbient)
+        for (auto& light : pArea->Lights(Index))
         {
-            mAmbientColor = light.Color();
-        }
-        else // Other lights will be used depending which are closest to the node
-        {
-            const bool IsInRange = AABox().IntersectsSphere(light.Position(), light.GetRadius());
-
-            if (IsInRange)
+            // Ambient lights should only be present one per layer; need to check how the game deals with multiple ambients
+            if (light.Type() == ELightType::LocalAmbient)
             {
-                const float Dist = mPosition.Distance(light.Position());
-                LightEntries.emplace_back(&light, Dist);
+                mAmbientColor = light.Color();
+            }
+            else // Other lights will be used depending which are closest to the node
+            {
+                const bool IsInRange = AABox().IntersectsSphere(light.Position(), light.GetRadius());
+
+                if (IsInRange)
+                {
+                    const float Dist = mPosition.Distance(light.Position());
+                    LightEntries.emplace_back(&light, Dist);
+                }
             }
         }
     }

--- a/src/Core/Scene/CScriptAttachNode.cpp
+++ b/src/Core/Scene/CScriptAttachNode.cpp
@@ -51,7 +51,7 @@ void CScriptAttachNode::AttachPropertyModified()
 
 void CScriptAttachNode::ParentDisplayAssetChanged(const CResource* pNewDisplayAsset)
 {
-    if (pNewDisplayAsset->Type() == EResourceType::AnimSet)
+    if (pNewDisplayAsset && pNewDisplayAsset->Type() == EResourceType::AnimSet)
     {
         const CSkeleton* pSkel = mpScriptNode->ActiveSkeleton();
         mpLocator = pSkel->BoneByName(mLocatorName);


### PR DESCRIPTION
Fixes for a couple crashes I've encountered. CSceneNode causes a crash when opening most (all?) DKCR levels, while CScriptAttachNode causes a crash when creating a new DigitalGuardian instance.